### PR TITLE
"Fix" for 8K RAM STM32F1 medium density devices

### DIFF
--- a/src/stm32f1.c
+++ b/src/stm32f1.c
@@ -60,16 +60,16 @@ static const char stm32hd_driver_str[] = "STM32, High density.";
 static const char stm32f3_driver_str[] = "STM32F3xx";
 static const char stm32f0_driver_str[] = "STM32F0xx";
 
-static const char stm32f1_xml_memory_map[] = "<?xml version=\"1.0\"?>"
-/*	"<!DOCTYPE memory-map "
-	"             PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
-	"                    \"http://sourceware.org/gdb/gdb-memory-map.dtd\">"*/
-	"<memory-map>"
-	"  <memory type=\"flash\" start=\"0x8000000\" length=\"0x20000\">"
-	"    <property name=\"blocksize\">0x400</property>"
-	"  </memory>"
-	"  <memory type=\"ram\" start=\"0x20000000\" length=\"0x5000\"/>"
-	"</memory-map>";
+//static const char stm32f1_xml_memory_map[] = "<?xml version=\"1.0\"?>"
+///*	"<!DOCTYPE memory-map "
+//	"             PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
+//	"                    \"http://sourceware.org/gdb/gdb-memory-map.dtd\">"*/
+//	"<memory-map>"
+//	"  <memory type=\"flash\" start=\"0x8000000\" length=\"0x20000\">"
+//	"    <property name=\"blocksize\">0x400</property>"
+//	"  </memory>"
+//	"  <memory type=\"ram\" start=\"0x20000000\" length=\"0x5000\"/>"
+//	"</memory-map>";
 
 static const char stm32hd_xml_memory_map[] = "<?xml version=\"1.0\"?>"
 /*	"<!DOCTYPE memory-map "
@@ -81,6 +81,17 @@ static const char stm32hd_xml_memory_map[] = "<?xml version=\"1.0\"?>"
 	"  </memory>"
 	"  <memory type=\"ram\" start=\"0x20000000\" length=\"0x10000\"/>"
 	"</memory-map>";
+
+static const char stm32f1_xml_memory_map[] = "<?xml version=\"1.0\"?>"
+/*	"<!DOCTYPE memory-map "
+ "             PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
+ "                    \"http://sourceware.org/gdb/gdb-memory-map.dtd\">"*/
+"<memory-map>"
+"  <memory type=\"flash\" start=\"0x8000000\" length=\"0x10000\">"
+"    <property name=\"blocksize\">0x400</property>"
+"  </memory>"
+"  <memory type=\"ram\" start=\"0x20000000\" length=\"0x2000\"/>"
+"</memory-map>";
 
 /* Flash Program ad Erase Controller Register Map */
 #define FPEC_BASE	0x40022000
@@ -158,7 +169,7 @@ bool stm32f1_probe(struct target_s *target)
 	idcode = adiv5_ap_mem_read(adiv5_target_ap(target), DBGMCU_IDCODE);
 	switch(idcode & 0xFFF) {
 	case 0x410:  /* Medium density */
-	case 0x412:  /* Low denisty */
+	case 0x412:  /* Low density */
 	case 0x420:  /* Value Line, Low-/Medium density */
 		target->driver = stm32f1_driver_str;
 		target->xml_mem_map = stm32f1_xml_memory_map;


### PR DESCRIPTION
This is not an actual pull request, but a rather more convenient form to discuss symptoms that I'm seeing with 8K RAM / 64K FLASH STM32F100 devices.

Those devices worked fine in older versions, but did not work in the current tree. My guess was because of the memory map that indicated 24K of RAM. Changing this to 8K fixed the flash errors and I'm able to flash devices.

Its however a hack, and some guidance on a proper resolution would be appreciated.