### PR TITLE
Fix to move stubs into rodata.

### DIFF
--- a/src/lmi.c
+++ b/src/lmi.c
@@ -63,7 +63,7 @@ static const char tm4c123gh6pm_xml_memory_map[] = "<?xml version=\"1.0\"?>"
 	"</memory-map>";
 
 
-uint16_t lmi_flash_write_stub[] = {
+static const uint16_t lmi_flash_write_stub[] = {
 // _start:
 	0x4809,	// ldr r0, [pc, #36] // _flashbase
 	0x490b,	// ldr r1, [pc, #44] // _addr

--- a/src/nrf51.c
+++ b/src/nrf51.c
@@ -98,7 +98,7 @@ static const char nrf51_xml_memory_map[] = "<?xml version=\"1.0\"?>"
 
 #define NRF51_PAGE_SIZE 1024
 
-uint16_t nrf51_flash_write_stub[] = {
+static const uint16_t nrf51_flash_write_stub[] = {
 // _start:
 	0x4808, // ldr	r0, [pc, #32]	; (24 <_ready>)
 	0x4909, // ldr	r1, [pc, #36]	; (28 <_addr>)

--- a/src/stm32f1.c
+++ b/src/stm32f1.c
@@ -122,7 +122,7 @@ static const char stm32hd_xml_memory_map[] = "<?xml version=\"1.0\"?>"
 #define DBGMCU_IDCODE	0xE0042000
 #define DBGMCU_IDCODE_F0	0x40015800
 
-uint16_t stm32f1_flash_write_stub[] = {
+static const uint16_t stm32f1_flash_write_stub[] = {
 // _start:
 	0x4809,	// ldr r0, [pc, #36] // _flashbase
 	0x490a,	// ldr r1, [pc, #40] // _addr

--- a/src/stm32f4.c
+++ b/src/stm32f4.c
@@ -122,7 +122,7 @@ static const char stm32f4_xml_memory_map[] = "<?xml version=\"1.0\"?>"
 #define DBGMCU_IDCODE	0xE0042000
 
 /* This routine is uses word access.  Only usable on target voltage >2.7V */
-uint16_t stm32f4_flash_write_stub[] = {
+static const uint16_t stm32f4_flash_write_stub[] = {
 // _start:
 	0x480a,	// ldr r0, [pc, #40] // _flashbase
 	0x490b,	// ldr r1, [pc, #44] // _addr


### PR DESCRIPTION
o Stubs were declared as globals which means they will be initialized
  data.  No need for this.  Now, stubs are static const and are only
  present in the program image.