### PR TITLE
Stm32lx

### DIFF
--- a/flashstub/README
+++ b/flashstub/README
@@ -1,5 +1,13 @@
-These are the assembler routines for executing a flash write
-on the supported targets.  They are kept here for reference, but
-are not used, as the compiled binary code is included in the 
-target drivers.
+Flash Stubs
+===========
 
+For most of the targets, these are assembler routines for executing
+a flash write on the supported targets.  They are kept here for
+reference, but are not used, as the compiled binary code is included
+in the target drivers.
+
+For the STM32l0x, the stubs are written in C++ and emitted as arrays
+of half-words for inclusion in the target driver.  The use of a higher
+level language allows more detailed code and for easy revisions.
+These stubs communicate with the driver through a structure defined in
+the src/include/stm32l0-nvm.h header.

--- a/flashstub/code-to-array.pl
+++ b/flashstub/code-to-array.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/perl
+#
+# Convert the output of objdump to an array of bytes are can include
+# into our program.
+
+while (<>) {
+    if (m/^\s*([0-9a-fA-F]+):\s*([0-9a-fA-F]+)(.*)/) {
+	my $addr = "0x$1";
+	my $value = $2;
+	if (length ($value) == 4) {
+	    print "  [$addr/2] = 0x$value, // $_";
+	}
+	else {
+	    my $lsb = substr ($value, 4, 4);
+	    my $msb = substr ($value, 0, 4);
+	    print "  [$addr/2] = 0x$lsb, // $_";
+	    print "  [$addr/2 + 1] = 0x$msb,\n";
+	}
+    }
+    else {
+	print "// ", $_;
+    }
+}
+

--- a/flashstub/stm32l05x-nvm-prog-erase.cc
+++ b/flashstub/stm32l05x-nvm-prog-erase.cc
@@ -1,0 +1,92 @@
+/* @file stm32l05x-nvm-prog-erase.cc
+ *
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2014 Woollysoft
+ * Written by Marc Singer <elf@woollysoft.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* -----------
+   DESCRIPTION
+   -----------
+
+   NVM program flash erase stub for STM32L05x, a Cortex-M0+ core.  The
+   stub uses SRAM to host the code fragment to perform the erase.
+
+   This stub should work with the STM32L1xx as well as long as the
+   page_size is set appropriately.  The L0's use a page size of 128
+   bytes.  The L1's use a page size of 256 bytes.
+
+   If you plan to modify this routine and emit a new stub, make sure
+   to audit the code.  We don't have a stack so we cannot make calls
+   that save the link pointer.  IOW, the inline functions should be be
+   inlined.
+
+   *** FIXME: clear errors before starting.
+
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include "../src/include/stm32lx-nvm.h"
+
+/* Erase a region of flash.  In the event that the erase is misaligned
+   with respect to pages, it will erase the pages that contain the
+   requested range of bytes. */
+extern "C" void __attribute((naked)) stm32l05x_nvm_prog_erase () {
+  // Leave room for INFO at second word of routine
+  __asm volatile ("b 0f\n\t"
+                  ".align 2\n\t"
+                  ".word 0\n\t"
+                  ".word 0\n\t"
+                  ".word 0\n\t"
+                  ".word 0\n\t"
+                  "0:");
+
+  // Align to the start of the first page so that we make sure to erase
+  // all of the target pages.
+  auto remainder    = reinterpret_cast<uint32_t> (Info.destination)
+    & (Info.page_size - 1);
+  Info.size        += remainder;
+  Info.destination -= remainder/sizeof (*Info.destination);
+
+  if (!unlock ())
+    goto quit;
+
+  // Enable erasing
+  Nvm.pecr = STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE;
+  if ((Nvm.pecr & (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+      != (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+    goto quit;
+
+  while (Info.size > 0) {
+    *Info.destination = 0;      // Initiate erase
+
+    Info.destination += Info.page_size/sizeof (*Info.destination);
+    Info.size -= Info.page_size;
+  }
+
+quit:
+  lock ();
+  __asm volatile ("bkpt");
+}
+
+/*
+   Local Variables:
+   compile-command: "/opt/arm/arm-none-eabi-g++ -mcpu=cortex-m0plus -g -c -std=c++11 -mthumb -o stm32l05x-nvm-prog-erase.o -Os -Wa,-ahndl=stm32l05x-nvm-prog-erase.lst stm32l05x-nvm-prog-erase.cc ; /opt/arm/arm-none-eabi-objdump -S stm32l05x-nvm-prog-erase.o | ./code-to-array.pl > stm32l05x-nvm-prog-erase.stub"
+   End:
+
+*/

--- a/flashstub/stm32l05x-nvm-prog-erase.stub
+++ b/flashstub/stm32l05x-nvm-prog-erase.stub
@@ -1,0 +1,148 @@
+// 
+// stm32l05x-nvm-prog-erase.o:     file format elf32-littlearm
+// 
+// 
+// Disassembly of section .text:
+// 
+// 00000000 <stm32l05x_nvm_prog_erase>:
+//                   ".align 2\n\t"
+//                   ".word 0\n\t"
+//                   ".word 0\n\t"
+//                   ".word 0\n\t"
+//                   ".word 0\n\t"
+//                   "0:");
+  [0x0/2] = 0xe008, //    0:	e008      	b.n	14 <stm32l05x_nvm_prog_erase+0x14>
+  [0x2/2] = 0x46c0, //    2:	46c0      	nop			; (mov r8, r8)
+// 	...
+// 
+//   // Align to the start of the first page so that we make sure to erase
+//   // all of the target pages.
+//   auto remainder    = reinterpret_cast<uint32_t> (Info.destination)
+//     & (Info.page_size - 1);
+  [0x14/2] = 0x4a1a, //   14:	4a1a      	ldr	r2, [pc, #104]	; (80 <stm32l05x_nvm_prog_erase+0x80>)
+  [0x16/2] = 0x68d3, //   16:	68d3      	ldr	r3, [r2, #12]
+  [0x18/2] = 0x6811, //   18:	6811      	ldr	r1, [r2, #0]
+//   Info.size        += remainder;
+  [0x1a/2] = 0x6850, //   1a:	6850      	ldr	r0, [r2, #4]
+//                   "0:");
+// 
+//   // Align to the start of the first page so that we make sure to erase
+//   // all of the target pages.
+//   auto remainder    = reinterpret_cast<uint32_t> (Info.destination)
+//     & (Info.page_size - 1);
+  [0x1c/2] = 0x3b01, //   1c:	3b01      	subs	r3, #1
+  [0x1e/2] = 0x400b, //   1e:	400b      	ands	r3, r1
+//   Info.size        += remainder;
+  [0x20/2] = 0x1818, //   20:	1818      	adds	r0, r3, r0
+//   Info.destination -= remainder/sizeof (*Info.destination);
+  [0x22/2] = 0x089b, //   22:	089b      	lsrs	r3, r3, #2
+  [0x24/2] = 0x009b, //   24:	009b      	lsls	r3, r3, #2
+  [0x26/2] = 0x1acb, //   26:	1acb      	subs	r3, r1, r3
+// #define Info (*reinterpret_cast<stm32lx_nvm_stub_info*>(STM32Lx_STUB_INFO_PHYS))
+// 
+// 
+// namespace {
+//   inline __attribute((always_inline)) bool unlock () {
+//     Nvm.pecr      = STM32Lx_NVM_PECR_PELOCK; // Lock to guarantee unlock
+  [0x28/2] = 0x2101, //   28:	2101      	movs	r1, #1
+  [0x2a/2] = 0x6013, //   2a:	6013      	str	r3, [r2, #0]
+  [0x2c/2] = 0x4b15, //   2c:	4b15      	ldr	r3, [pc, #84]	; (84 <stm32l05x_nvm_prog_erase+0x84>)
+// 
+//   // Align to the start of the first page so that we make sure to erase
+//   // all of the target pages.
+//   auto remainder    = reinterpret_cast<uint32_t> (Info.destination)
+//     & (Info.page_size - 1);
+//   Info.size        += remainder;
+  [0x2e/2] = 0x6050, //   2e:	6050      	str	r0, [r2, #4]
+  [0x30/2] = 0x6059, //   30:	6059      	str	r1, [r3, #4]
+//     Nvm.pkeyr     = STM32::NVM::PKEY1;
+  [0x32/2] = 0x4915, //   32:	4915      	ldr	r1, [pc, #84]	; (88 <stm32l05x_nvm_prog_erase+0x88>)
+  [0x34/2] = 0x60d9, //   34:	60d9      	str	r1, [r3, #12]
+//     Nvm.pkeyr     = STM32::NVM::PKEY2;
+  [0x36/2] = 0x4915, //   36:	4915      	ldr	r1, [pc, #84]	; (8c <stm32l05x_nvm_prog_erase+0x8c>)
+  [0x38/2] = 0x60d9, //   38:	60d9      	str	r1, [r3, #12]
+//     Nvm.prgkeyr   = STM32::NVM::PRGKEY1;
+  [0x3a/2] = 0x4915, //   3a:	4915      	ldr	r1, [pc, #84]	; (90 <stm32l05x_nvm_prog_erase+0x90>)
+  [0x3c/2] = 0x6119, //   3c:	6119      	str	r1, [r3, #16]
+//     Nvm.prgkeyr   = STM32::NVM::PRGKEY2;
+  [0x3e/2] = 0x4915, //   3e:	4915      	ldr	r1, [pc, #84]	; (94 <stm32l05x_nvm_prog_erase+0x94>)
+  [0x40/2] = 0x6119, //   40:	6119      	str	r1, [r3, #16]
+//     return !(Nvm.pecr & STM32Lx_NVM_PECR_PRGLOCK);
+  [0x42/2] = 0x6858, //   42:	6858      	ldr	r0, [r3, #4]
+  [0x44/2] = 0x1c11, //   44:	1c11      	adds	r1, r2, #0
+//   Info.destination -= remainder/sizeof (*Info.destination);
+// 
+//   if (!unlock ())
+  [0x46/2] = 0x0782, //   46:	0782      	lsls	r2, r0, #30
+  [0x48/2] = 0xd502, //   48:	d502      	bpl.n	50 <stm32l05x_nvm_prog_erase+0x50>
+//   }
+//   inline __attribute((always_inline)) void lock () {
+//     Nvm.pecr      = STM32Lx_NVM_PECR_PELOCK; }
+  [0x4a/2] = 0x2201, //   4a:	2201      	movs	r2, #1
+  [0x4c/2] = 0x605a, //   4c:	605a      	str	r2, [r3, #4]
+//     Info.size -= Info.page_size;
+//   }
+// 
+// quit:
+//   lock ();
+//   __asm volatile ("bkpt");
+  [0x4e/2] = 0xbe00, //   4e:	be00      	bkpt	0x0000
+// 
+//   if (!unlock ())
+//     goto quit;
+// 
+//   // Enable erasing
+//   Nvm.pecr = STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE;
+  [0x50/2] = 0x2282, //   50:	2282      	movs	r2, #130	; 0x82
+  [0x52/2] = 0x0092, //   52:	0092      	lsls	r2, r2, #2
+  [0x54/2] = 0x605a, //   54:	605a      	str	r2, [r3, #4]
+//   if ((Nvm.pecr & (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+  [0x56/2] = 0x6858, //   56:	6858      	ldr	r0, [r3, #4]
+  [0x58/2] = 0x4010, //   58:	4010      	ands	r0, r2
+  [0x5a/2] = 0x4290, //   5a:	4290      	cmp	r0, r2
+  [0x5c/2] = 0xd1f5, //   5c:	d1f5      	bne.n	4a <stm32l05x_nvm_prog_erase+0x4a>
+//       != (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+//     goto quit;
+// 
+//   while (Info.size > 0) {
+  [0x5e/2] = 0x6848, //   5e:	6848      	ldr	r0, [r1, #4]
+  [0x60/2] = 0x4a07, //   60:	4a07      	ldr	r2, [pc, #28]	; (80 <stm32l05x_nvm_prog_erase+0x80>)
+  [0x62/2] = 0x2800, //   62:	2800      	cmp	r0, #0
+  [0x64/2] = 0xddf1, //   64:	ddf1      	ble.n	4a <stm32l05x_nvm_prog_erase+0x4a>
+//     *Info.destination = 0;      // Initiate erase
+  [0x66/2] = 0x2400, //   66:	2400      	movs	r4, #0
+  [0x68/2] = 0x6810, //   68:	6810      	ldr	r0, [r2, #0]
+// 
+//     Info.destination += Info.page_size/sizeof (*Info.destination);
+  [0x6a/2] = 0x6815, //   6a:	6815      	ldr	r5, [r2, #0]
+//   if ((Nvm.pecr & (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+//       != (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+//     goto quit;
+// 
+//   while (Info.size > 0) {
+//     *Info.destination = 0;      // Initiate erase
+  [0x6c/2] = 0x6004, //   6c:	6004      	str	r4, [r0, #0]
+// 
+//     Info.destination += Info.page_size/sizeof (*Info.destination);
+  [0x6e/2] = 0x68d4, //   6e:	68d4      	ldr	r4, [r2, #12]
+  [0x70/2] = 0x08a0, //   70:	08a0      	lsrs	r0, r4, #2
+  [0x72/2] = 0x0080, //   72:	0080      	lsls	r0, r0, #2
+  [0x74/2] = 0x1828, //   74:	1828      	adds	r0, r5, r0
+  [0x76/2] = 0x6010, //   76:	6010      	str	r0, [r2, #0]
+//     Info.size -= Info.page_size;
+  [0x78/2] = 0x6850, //   78:	6850      	ldr	r0, [r2, #4]
+  [0x7a/2] = 0x1b00, //   7a:	1b00      	subs	r0, r0, r4
+  [0x7c/2] = 0x6050, //   7c:	6050      	str	r0, [r2, #4]
+  [0x7e/2] = 0xe7ee, //   7e:	e7ee      	b.n	5e <stm32l05x_nvm_prog_erase+0x5e>
+  [0x80/2] = 0x0004, //   80:	20000004 	.word	0x20000004
+  [0x80/2 + 1] = 0x2000,
+  [0x84/2] = 0x2000, //   84:	40022000 	.word	0x40022000
+  [0x84/2 + 1] = 0x4002,
+  [0x88/2] = 0xcdef, //   88:	89abcdef 	.word	0x89abcdef
+  [0x88/2 + 1] = 0x89ab,
+  [0x8c/2] = 0x0405, //   8c:	02030405 	.word	0x02030405
+  [0x8c/2 + 1] = 0x0203,
+  [0x90/2] = 0xaebf, //   90:	8c9daebf 	.word	0x8c9daebf
+  [0x90/2 + 1] = 0x8c9d,
+  [0x94/2] = 0x1516, //   94:	13141516 	.word	0x13141516
+  [0x94/2 + 1] = 0x1314,

--- a/flashstub/stm32l05x-nvm-prog-write.cc
+++ b/flashstub/stm32l05x-nvm-prog-write.cc
@@ -1,0 +1,110 @@
+/* @file stm32l05x-nvm-prog-write.cc
+ *
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2014 Woollysoft
+ * Written by Marc Singer <elf@woollysoft.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* -----------
+   DESCRIPTION
+   -----------
+
+   NVM program flash writing stub for STM32L05x, a Cortex-M0+ core.
+   The stub uses SRAM to host the code fragment and source data to
+   perform a write to flash.
+
+   This stub should work with the STM32L1xx as well as long as the
+   page_size is set appropriately.  The L0's use a page size of 128
+   bytes.  The L1's use a page size of 256 bytes.
+
+   If you plan to modify this routine and emit a new stub, make sure
+   to audit the code.  We don't have a stack so we cannot make calls
+   that save the link pointer.  IOW, the inline functions should be be
+   inlined.
+
+   *** FIXME: clear errors before starting.
+
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include "../src/include/stm32lx-nvm.h"
+
+/* Write a block of bytes to flash.  The called is responsible for
+   making sure that the address are aligned and that the count is an
+   even multiple of words. */
+extern "C" void __attribute((naked)) stm32l05x_nvm_prog_write () {
+  // Leave room for INFO at second word of routine
+  __asm volatile ("b 0f\n\t"
+                  ".align 2\n\t"
+                  ".word 0\n\t"
+                  ".word 0\n\t"
+                  ".word 0\n\t"
+                  ".word 0\n\t"
+                  "0:");
+
+  if (!unlock ())
+    goto quit;
+
+  while (Info.size > 0) {
+
+    // Either we're not half-page aligned or we have less than a half
+    // page to write
+    if (Info.size < Info.page_size/2
+        || (reinterpret_cast<uint32_t> (Info.destination)
+            & (Info.page_size/2 - 1))) {
+      Nvm.pecr = STM32Lx_NVM_PECR_PROG; // Word programming
+      size_t c = Info.page_size/2
+        - (reinterpret_cast<uint32_t> (Info.destination)
+           & (Info.page_size/2 - 1));
+      if (c > Info.size)
+        c = Info.size;
+      Info.size -= c;
+      c /= 4;
+      while (c--) {
+        uint32_t v = *Info.source++;
+        *Info.destination++ = v;
+        if (Nvm.sr & STM32Lx_NVM_SR_ERR_M)
+          goto quit;
+      }
+    }
+    // Or we are writing a half-page
+    else {
+      Nvm.pecr = STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_FPRG; // Half-page prg
+      size_t c = Info.page_size/2;
+      Info.size -= c;
+      c /= 4;
+      while (c--) {
+        uint32_t v = *Info.source++;
+        *Info.destination++ = v;
+      }
+      if (Nvm.sr & STM32Lx_NVM_SR_ERR_M)
+        goto quit;
+    }
+  }
+
+quit:
+  lock ();
+  __asm volatile ("bkpt");
+}
+
+/*
+   Local Variables:
+   compile-command: "/opt/arm/arm-none-eabi-g++ -mcpu=cortex-m0plus -g -c -std=c++11 -mthumb -o stm32l05x-nvm-prog-write.o -Os -Wa,-ahndl=stm32l05x-nvm-prog-write.lst stm32l05x-nvm-prog-write.cc ; /opt/arm/arm-none-eabi-objdump -S stm32l05x-nvm-prog-write.o | ./code-to-array.pl > stm32l05x-nvm-prog-write.stub"
+   End:
+
+*/

--- a/flashstub/stm32l05x-nvm-prog-write.stub
+++ b/flashstub/stm32l05x-nvm-prog-write.stub
@@ -1,0 +1,184 @@
+// 
+// stm32l05x-nvm-prog-write.o:     file format elf32-littlearm
+// 
+// 
+// Disassembly of section .text:
+// 
+// 00000000 <stm32l05x_nvm_prog_write>:
+//                   ".align 2\n\t"
+//                   ".word 0\n\t"
+//                   ".word 0\n\t"
+//                   ".word 0\n\t"
+//                   ".word 0\n\t"
+//                   "0:");
+  [0x0/2] = 0xe008, //    0:	e008      	b.n	14 <stm32l05x_nvm_prog_write+0x14>
+  [0x2/2] = 0x46c0, //    2:	46c0      	nop			; (mov r8, r8)
+// 	...
+// #define Info (*reinterpret_cast<stm32lx_nvm_stub_info*>(STM32Lx_STUB_INFO_PHYS))
+// 
+// 
+// namespace {
+//   inline __attribute((always_inline)) bool unlock () {
+//     Nvm.pecr      = STM32Lx_NVM_PECR_PELOCK; // Lock to guarantee unlock
+  [0x14/2] = 0x2201, //   14:	2201      	movs	r2, #1
+  [0x16/2] = 0x4b28, //   16:	4b28      	ldr	r3, [pc, #160]	; (b8 <stm32l05x_nvm_prog_write+0xb8>)
+  [0x18/2] = 0x605a, //   18:	605a      	str	r2, [r3, #4]
+//     Nvm.pkeyr     = STM32::NVM::PKEY1;
+  [0x1a/2] = 0x4a28, //   1a:	4a28      	ldr	r2, [pc, #160]	; (bc <stm32l05x_nvm_prog_write+0xbc>)
+  [0x1c/2] = 0x1c18, //   1c:	1c18      	adds	r0, r3, #0
+  [0x1e/2] = 0x60da, //   1e:	60da      	str	r2, [r3, #12]
+//     Nvm.pkeyr     = STM32::NVM::PKEY2;
+  [0x20/2] = 0x4a27, //   20:	4a27      	ldr	r2, [pc, #156]	; (c0 <stm32l05x_nvm_prog_write+0xc0>)
+  [0x22/2] = 0x60da, //   22:	60da      	str	r2, [r3, #12]
+//     Nvm.prgkeyr   = STM32::NVM::PRGKEY1;
+  [0x24/2] = 0x4a27, //   24:	4a27      	ldr	r2, [pc, #156]	; (c4 <stm32l05x_nvm_prog_write+0xc4>)
+  [0x26/2] = 0x611a, //   26:	611a      	str	r2, [r3, #16]
+//     Nvm.prgkeyr   = STM32::NVM::PRGKEY2;
+  [0x28/2] = 0x4a27, //   28:	4a27      	ldr	r2, [pc, #156]	; (c8 <stm32l05x_nvm_prog_write+0xc8>)
+  [0x2a/2] = 0x611a, //   2a:	611a      	str	r2, [r3, #16]
+//     return !(Nvm.pecr & STM32Lx_NVM_PECR_PRGLOCK);
+  [0x2c/2] = 0x685a, //   2c:	685a      	ldr	r2, [r3, #4]
+// 
+//   if (!unlock ())
+  [0x2e/2] = 0x0793, //   2e:	0793      	lsls	r3, r2, #30
+  [0x30/2] = 0xd514, //   30:	d514      	bpl.n	5c <stm32l05x_nvm_prog_write+0x5c>
+//   }
+//   inline __attribute((always_inline)) void lock () {
+//     Nvm.pecr      = STM32Lx_NVM_PECR_PELOCK; }
+  [0x32/2] = 0x2301, //   32:	2301      	movs	r3, #1
+  [0x34/2] = 0x6043, //   34:	6043      	str	r3, [r0, #4]
+//     }
+//   }
+// 
+// quit:
+//   lock ();
+//   __asm volatile ("bkpt");
+  [0x36/2] = 0xbe00, //   36:	be00      	bkpt	0x0000
+// 
+//   while (Info.size > 0) {
+// 
+//     // Either we're not half-page aligned or we have less than a half
+//     // page to write
+//     if (Info.size < Info.page_size/2
+  [0x38/2] = 0x68cd, //   38:	68cd      	ldr	r5, [r1, #12]
+  [0x3a/2] = 0x086e, //   3a:	086e      	lsrs	r6, r5, #1
+  [0x3c/2] = 0x1e73, //   3c:	1e73      	subs	r3, r6, #1
+  [0x3e/2] = 0x42b2, //   3e:	42b2      	cmp	r2, r6
+  [0x40/2] = 0xd212, //   40:	d212      	bcs.n	68 <stm32l05x_nvm_prog_write+0x68>
+//         || (reinterpret_cast<uint32_t> (Info.destination)
+//             & (Info.page_size/2 - 1))) {
+//       Nvm.pecr = STM32Lx_NVM_PECR_PROG; // Word programming
+  [0x42/2] = 0x2508, //   42:	2508      	movs	r5, #8
+  [0x44/2] = 0x6045, //   44:	6045      	str	r5, [r0, #4]
+//       size_t c = Info.page_size/2
+//         - (reinterpret_cast<uint32_t> (Info.destination)
+//            & (Info.page_size/2 - 1));
+  [0x46/2] = 0x680d, //   46:	680d      	ldr	r5, [r1, #0]
+  [0x48/2] = 0x402b, //   48:	402b      	ands	r3, r5
+  [0x4a/2] = 0x1af3, //   4a:	1af3      	subs	r3, r6, r3
+  [0x4c/2] = 0x4293, //   4c:	4293      	cmp	r3, r2
+  [0x4e/2] = 0xd900, //   4e:	d900      	bls.n	52 <stm32l05x_nvm_prog_write+0x52>
+  [0x50/2] = 0x1c13, //   50:	1c13      	adds	r3, r2, #0
+//       if (c > Info.size)
+//         c = Info.size;
+//       Info.size -= c;
+  [0x52/2] = 0x1ad2, //   52:	1ad2      	subs	r2, r2, r3
+  [0x54/2] = 0x604a, //   54:	604a      	str	r2, [r1, #4]
+//       c /= 4;
+  [0x56/2] = 0x089b, //   56:	089b      	lsrs	r3, r3, #2
+//       while (c--) {
+  [0x58/2] = 0x3b01, //   58:	3b01      	subs	r3, #1
+  [0x5a/2] = 0xd209, //   5a:	d209      	bcs.n	70 <stm32l05x_nvm_prog_write+0x70>
+//                   "0:");
+// 
+//   if (!unlock ())
+//     goto quit;
+// 
+//   while (Info.size > 0) {
+  [0x5c/2] = 0x491b, //   5c:	491b      	ldr	r1, [pc, #108]	; (cc <stm32l05x_nvm_prog_write+0xcc>)
+  [0x5e/2] = 0x684a, //   5e:	684a      	ldr	r2, [r1, #4]
+  [0x60/2] = 0x1c0c, //   60:	1c0c      	adds	r4, r1, #0
+  [0x62/2] = 0x2a00, //   62:	2a00      	cmp	r2, #0
+  [0x64/2] = 0xdce8, //   64:	dce8      	bgt.n	38 <stm32l05x_nvm_prog_write+0x38>
+  [0x66/2] = 0xe7e4, //   66:	e7e4      	b.n	32 <stm32l05x_nvm_prog_write+0x32>
+// 
+//     // Either we're not half-page aligned or we have less than a half
+//     // page to write
+//     if (Info.size < Info.page_size/2
+//         || (reinterpret_cast<uint32_t> (Info.destination)
+  [0x68/2] = 0x680f, //   68:	680f      	ldr	r7, [r1, #0]
+  [0x6a/2] = 0x421f, //   6a:	421f      	tst	r7, r3
+  [0x6c/2] = 0xd00d, //   6c:	d00d      	beq.n	8a <stm32l05x_nvm_prog_write+0x8a>
+  [0x6e/2] = 0xe7e8, //   6e:	e7e8      	b.n	42 <stm32l05x_nvm_prog_write+0x42>
+//       if (c > Info.size)
+//         c = Info.size;
+//       Info.size -= c;
+//       c /= 4;
+//       while (c--) {
+//         uint32_t v = *Info.source++;
+  [0x70/2] = 0x68a2, //   70:	68a2      	ldr	r2, [r4, #8]
+  [0x72/2] = 0x1d11, //   72:	1d11      	adds	r1, r2, #4
+  [0x74/2] = 0x60a1, //   74:	60a1      	str	r1, [r4, #8]
+  [0x76/2] = 0x6811, //   76:	6811      	ldr	r1, [r2, #0]
+//         *Info.destination++ = v;
+  [0x78/2] = 0x6822, //   78:	6822      	ldr	r2, [r4, #0]
+  [0x7a/2] = 0x1d15, //   7a:	1d15      	adds	r5, r2, #4
+  [0x7c/2] = 0x6025, //   7c:	6025      	str	r5, [r4, #0]
+  [0x7e/2] = 0x6011, //   7e:	6011      	str	r1, [r2, #0]
+//         if (Nvm.sr & STM32Lx_NVM_SR_ERR_M)
+  [0x80/2] = 0x6981, //   80:	6981      	ldr	r1, [r0, #24]
+  [0x82/2] = 0x4a13, //   82:	4a13      	ldr	r2, [pc, #76]	; (d0 <stm32l05x_nvm_prog_write+0xd0>)
+  [0x84/2] = 0x4211, //   84:	4211      	tst	r1, r2
+  [0x86/2] = 0xd0e7, //   86:	d0e7      	beq.n	58 <stm32l05x_nvm_prog_write+0x58>
+  [0x88/2] = 0xe7d3, //   88:	e7d3      	b.n	32 <stm32l05x_nvm_prog_write+0x32>
+//           goto quit;
+//       }
+//     }
+//     // Or we are writing a half-page
+//     else {
+//       Nvm.pecr = STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_FPRG; // Half-page prg
+  [0x8a/2] = 0x2381, //   8a:	2381      	movs	r3, #129	; 0x81
+  [0x8c/2] = 0x00db, //   8c:	00db      	lsls	r3, r3, #3
+  [0x8e/2] = 0x6043, //   8e:	6043      	str	r3, [r0, #4]
+//       size_t c = Info.page_size/2;
+//       Info.size -= c;
+  [0x90/2] = 0x1b93, //   90:	1b93      	subs	r3, r2, r6
+  [0x92/2] = 0x604b, //   92:	604b      	str	r3, [r1, #4]
+//       c /= 4;
+  [0x94/2] = 0x08eb, //   94:	08eb      	lsrs	r3, r5, #3
+//       while (c--) {
+  [0x96/2] = 0x3b01, //   96:	3b01      	subs	r3, #1
+  [0x98/2] = 0xd308, //   98:	d308      	bcc.n	ac <stm32l05x_nvm_prog_write+0xac>
+//         uint32_t v = *Info.source++;
+  [0x9a/2] = 0x68a2, //   9a:	68a2      	ldr	r2, [r4, #8]
+  [0x9c/2] = 0x1d11, //   9c:	1d11      	adds	r1, r2, #4
+  [0x9e/2] = 0x60a1, //   9e:	60a1      	str	r1, [r4, #8]
+  [0xa0/2] = 0x6811, //   a0:	6811      	ldr	r1, [r2, #0]
+//         *Info.destination++ = v;
+  [0xa2/2] = 0x6822, //   a2:	6822      	ldr	r2, [r4, #0]
+  [0xa4/2] = 0x1d15, //   a4:	1d15      	adds	r5, r2, #4
+  [0xa6/2] = 0x6025, //   a6:	6025      	str	r5, [r4, #0]
+  [0xa8/2] = 0x6011, //   a8:	6011      	str	r1, [r2, #0]
+  [0xaa/2] = 0xe7f4, //   aa:	e7f4      	b.n	96 <stm32l05x_nvm_prog_write+0x96>
+//       }
+//       if (Nvm.sr & STM32Lx_NVM_SR_ERR_M)
+  [0xac/2] = 0x6982, //   ac:	6982      	ldr	r2, [r0, #24]
+  [0xae/2] = 0x4b08, //   ae:	4b08      	ldr	r3, [pc, #32]	; (d0 <stm32l05x_nvm_prog_write+0xd0>)
+  [0xb0/2] = 0x421a, //   b0:	421a      	tst	r2, r3
+  [0xb2/2] = 0xd0d3, //   b2:	d0d3      	beq.n	5c <stm32l05x_nvm_prog_write+0x5c>
+  [0xb4/2] = 0xe7bd, //   b4:	e7bd      	b.n	32 <stm32l05x_nvm_prog_write+0x32>
+  [0xb6/2] = 0x46c0, //   b6:	46c0      	nop			; (mov r8, r8)
+  [0xb8/2] = 0x2000, //   b8:	40022000 	.word	0x40022000
+  [0xb8/2 + 1] = 0x4002,
+  [0xbc/2] = 0xcdef, //   bc:	89abcdef 	.word	0x89abcdef
+  [0xbc/2 + 1] = 0x89ab,
+  [0xc0/2] = 0x0405, //   c0:	02030405 	.word	0x02030405
+  [0xc0/2 + 1] = 0x0203,
+  [0xc4/2] = 0xaebf, //   c4:	8c9daebf 	.word	0x8c9daebf
+  [0xc4/2 + 1] = 0x8c9d,
+  [0xc8/2] = 0x1516, //   c8:	13141516 	.word	0x13141516
+  [0xc8/2 + 1] = 0x1314,
+  [0xcc/2] = 0x0004, //   cc:	20000004 	.word	0x20000004
+  [0xcc/2 + 1] = 0x2000,
+  [0xd0/2] = 0x0700, //   d0:	00010700 	.word	0x00010700
+  [0xd0/2 + 1] = 0x0001,

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,8 @@ BUILDDATE := `date +"%Y%m%d"`
 
 CFLAGS += -Wall -Wextra -Wno-pointer-sign -Wno-char-subscripts\
 	-Wno-sign-compare \
-	-O2 -std=gnu99 -g3 -DBUILDDATE=\"$(BUILDDATE)\"\
+	-O2 \
+	-std=gnu99 -g3 -DBUILDDATE=\"$(BUILDDATE)\"\
 	-I. -Iinclude -I$(PLATFORM_DIR) \
 	-DVERSION_SUFFIX=\"`../scripts/setlocalversion`\" -MD
 
@@ -35,6 +36,7 @@ SRC =			\
 	samd20.c	\
 	stm32f1.c	\
 	stm32f4.c	\
+	stm32l0.c	\
 	stm32l1.c	\
 	swdptap.c	\
 	target.c	\

--- a/src/cortexm.c
+++ b/src/cortexm.c
@@ -40,6 +40,7 @@
 #include "target.h"
 #include "command.h"
 #include "gdb_packet.h"
+#include "cortexm.h"
 
 static char cortexm_driver_str[] = "ARM Cortex-M";
 
@@ -54,142 +55,18 @@ const struct command_s cortexm_cmd_list[] = {
 #define	TOPT_FLAVOUR_V6M	(1<<0)	/* if not set, target is assumed to be v7m */
 #define	TOPT_FLAVOUR_V7MF	(1<<1)	/* if set, floating-point enabled. */
 
-/* Private peripheral bus base address */
-#define CORTEXM_PPB_BASE	0xE0000000
-
-#define CORTEXM_SCS_BASE	(CORTEXM_PPB_BASE + 0xE000)
-
-#define CORTEXM_AIRCR		(CORTEXM_SCS_BASE + 0xD0C)
-#define CORTEXM_CFSR		(CORTEXM_SCS_BASE + 0xD28)
-#define CORTEXM_HFSR		(CORTEXM_SCS_BASE + 0xD2C)
-#define CORTEXM_DFSR		(CORTEXM_SCS_BASE + 0xD30)
-#define CORTEXM_CPACR		(CORTEXM_SCS_BASE + 0xD88)
-#define CORTEXM_DHCSR		(CORTEXM_SCS_BASE + 0xDF0)
-#define CORTEXM_DCRSR		(CORTEXM_SCS_BASE + 0xDF4)
-#define CORTEXM_DCRDR		(CORTEXM_SCS_BASE + 0xDF8)
-#define CORTEXM_DEMCR		(CORTEXM_SCS_BASE + 0xDFC)
-
-#define CORTEXM_FPB_BASE	(CORTEXM_PPB_BASE + 0x2000)
-
-/* ARM Literature uses FP_*, we use CORTEXM_FPB_* consistently */
-#define CORTEXM_FPB_CTRL	(CORTEXM_FPB_BASE + 0x000)
-#define CORTEXM_FPB_REMAP	(CORTEXM_FPB_BASE + 0x004)
-#define CORTEXM_FPB_COMP(i)	(CORTEXM_FPB_BASE + 0x008 + (4*(i)))
-
-#define CORTEXM_DWT_BASE	(CORTEXM_PPB_BASE + 0x1000)
-
-#define CORTEXM_DWT_CTRL	(CORTEXM_DWT_BASE + 0x000)
-#define CORTEXM_DWT_COMP(i)	(CORTEXM_DWT_BASE + 0x020 + (0x10*(i)))
-#define CORTEXM_DWT_MASK(i)	(CORTEXM_DWT_BASE + 0x024 + (0x10*(i)))
-#define CORTEXM_DWT_FUNC(i)	(CORTEXM_DWT_BASE + 0x028 + (0x10*(i)))
-
-/* Application Interrupt and Reset Control Register (AIRCR) */
-#define CORTEXM_AIRCR_VECTKEY		(0x05FA << 16)
-/* Bits 31:16 - Read as VECTKETSTAT, 0xFA05 */
-#define CORTEXM_AIRCR_ENDIANESS		(1 << 15)
-/* Bits 15:11 - Unused, reserved */
-#define CORTEXM_AIRCR_PRIGROUP		(7 << 8)
-/* Bits 7:3 - Unused, reserved */
-#define CORTEXM_AIRCR_SYSRESETREQ	(1 << 2)
-#define CORTEXM_AIRCR_VECTCLRACTIVE	(1 << 1)
-#define CORTEXM_AIRCR_VECTRESET		(1 << 0)
-
-/* HardFault Status Register (HFSR) */
-#define CORTEXM_HFSR_DEBUGEVT		(1 << 31)
-#define CORTEXM_HFSR_FORCED		(1 << 30)
-/* Bits 29:2 - Not specified */
-#define CORTEXM_HFSR_VECTTBL		(1 << 1)
-/* Bits 0 - Reserved */
-
-/* Debug Fault Status Register (DFSR) */
-/* Bits 31:5 - Reserved */
-#define CORTEXM_DFSR_RESETALL		0x1F
-#define CORTEXM_DFSR_EXTERNAL		(1 << 4)
-#define CORTEXM_DFSR_VCATCH		(1 << 3)
-#define CORTEXM_DFSR_DWTTRAP		(1 << 2)
-#define CORTEXM_DFSR_BKPT		(1 << 1)
-#define CORTEXM_DFSR_HALTED		(1 << 0)
-
-/* Debug Halting Control and Status Register (DHCSR) */
-/* This key must be written to bits 31:16 for write to take effect */
-#define CORTEXM_DHCSR_DBGKEY		0xA05F0000
-/* Bits 31:26 - Reserved */
-#define CORTEXM_DHCSR_S_RESET_ST	(1 << 25)
-#define CORTEXM_DHCSR_S_RETIRE_ST	(1 << 24)
-/* Bits 23:20 - Reserved */
-#define CORTEXM_DHCSR_S_LOCKUP		(1 << 19)
-#define CORTEXM_DHCSR_S_SLEEP		(1 << 18)
-#define CORTEXM_DHCSR_S_HALT		(1 << 17)
-#define CORTEXM_DHCSR_S_REGRDY		(1 << 16)
-/* Bits 15:6 - Reserved */
-#define CORTEXM_DHCSR_C_SNAPSTALL	(1 << 5)	/* v7m only */
-/* Bit 4 - Reserved */
-#define CORTEXM_DHCSR_C_MASKINTS	(1 << 3)
-#define CORTEXM_DHCSR_C_STEP		(1 << 2)
-#define CORTEXM_DHCSR_C_HALT		(1 << 1)
-#define CORTEXM_DHCSR_C_DEBUGEN		(1 << 0)
-
-/* Debug Core Register Selector Register (DCRSR) */
-#define CORTEXM_DCRSR_REGWnR		0x00010000
-#define CORTEXM_DCRSR_REGSEL_MASK	0x0000001F
-#define CORTEXM_DCRSR_REGSEL_XPSR	0x00000010
-#define CORTEXM_DCRSR_REGSEL_MSP	0x00000011
-#define CORTEXM_DCRSR_REGSEL_PSP	0x00000012
-
-/* Debug Exception and Monitor Control Register (DEMCR) */
-/* Bits 31:25 - Reserved */
-#define CORTEXM_DEMCR_TRCENA		(1 << 24)
-/* Bits 23:20 - Reserved */
-#define CORTEXM_DEMCR_MON_REQ		(1 << 19)	/* v7m only */
-#define CORTEXM_DEMCR_MON_STEP		(1 << 18)	/* v7m only */
-#define CORTEXM_DEMCR_VC_MON_PEND	(1 << 17)	/* v7m only */
-#define CORTEXM_DEMCR_VC_MON_EN		(1 << 16)	/* v7m only */
-/* Bits 15:11 - Reserved */
-#define CORTEXM_DEMCR_VC_HARDERR	(1 << 10)
-#define CORTEXM_DEMCR_VC_INTERR		(1 << 9)	/* v7m only */
-#define CORTEXM_DEMCR_VC_BUSERR		(1 << 8)	/* v7m only */
-#define CORTEXM_DEMCR_VC_STATERR	(1 << 7)	/* v7m only */
-#define CORTEXM_DEMCR_VC_CHKERR		(1 << 6)	/* v7m only */
-#define CORTEXM_DEMCR_VC_NOCPERR	(1 << 5)	/* v7m only */
-#define CORTEXM_DEMCR_VC_MMERR		(1 << 4)	/* v7m only */
-/* Bits 3:1 - Reserved */
-#define CORTEXM_DEMCR_VC_CORERESET	(1 << 0)
-
-/* Flash Patch and Breakpoint Control Register (FP_CTRL) */
-/* Bits 32:15 - Reserved */
-/* Bits 14:12 - NUM_CODE2 */	/* v7m only */
-/* Bits 11:8 - NUM_LIT */	/* v7m only */
-/* Bits 7:4 - NUM_CODE1 */
-/* Bits 3:2 - Unspecified */
-#define CORTEXM_FPB_CTRL_KEY		(1 << 1)
-#define CORTEXM_FPB_CTRL_ENABLE		(1 << 0)
-
-/* Data Watchpoint and Trace Mask Register (DWT_MASKx) */
-#define CORTEXM_DWT_MASK_BYTE		(0 << 0)
-#define CORTEXM_DWT_MASK_HALFWORD	(1 << 0)
-#define CORTEXM_DWT_MASK_WORD		(3 << 0)
-
-/* Data Watchpoint and Trace Function Register (DWT_FUNCTIONx) */
-#define CORTEXM_DWT_FUNC_MATCHED	(1 << 24)
-#define CORTEXM_DWT_FUNC_DATAVSIZE_WORD	(2 << 10)	/* v7m only */
-#define CORTEXM_DWT_FUNC_FUNC_READ	(5 << 0)
-#define CORTEXM_DWT_FUNC_FUNC_WRITE	(6 << 0)
-#define CORTEXM_DWT_FUNC_FUNC_ACCESS	(7 << 0)
-
 /* Signals returned by cortexm_halt_wait() */
 #define SIGINT 2
 #define SIGTRAP 5
 #define SIGSEGV 11
 
 static bool cortexm_attach(struct target_s *target);
-static void cortexm_detach(struct target_s *target);
 
 static int cortexm_regs_read(struct target_s *target, void *data);
 static int cortexm_regs_write(struct target_s *target, const void *data);
 static int cortexm_pc_write(struct target_s *target, const uint32_t val);
 
 static void cortexm_reset(struct target_s *target);
-static void cortexm_halt_resume(struct target_s *target, bool step);
 static int cortexm_halt_wait(struct target_s *target);
 static void cortexm_halt_request(struct target_s *target);
 static int cortexm_fault_unwind(struct target_s *target);
@@ -456,8 +333,7 @@ cortexm_attach(struct target_s *target)
 	return true;
 }
 
-static void
-cortexm_detach(struct target_s *target)
+void cortexm_detach(struct target_s *target)
 {
 	ADIv5_AP_t *ap = adiv5_target_ap(target);
 	struct cortexm_priv *priv = ap->priv;
@@ -646,14 +522,14 @@ cortexm_halt_wait(struct target_s *target)
 
 }
 
-static void
-cortexm_halt_resume(struct target_s *target, bool step)
+void cortexm_halt_resume(struct target_s *target, bool step)
 {
 	ADIv5_AP_t *ap = adiv5_target_ap(target);
 	struct cortexm_priv *priv = ap->priv;
 	uint32_t dhcsr = CORTEXM_DHCSR_DBGKEY | CORTEXM_DHCSR_C_DEBUGEN;
 
-	if(step) dhcsr |= CORTEXM_DHCSR_C_STEP | CORTEXM_DHCSR_C_MASKINTS;
+	if (step)
+		dhcsr |= CORTEXM_DHCSR_C_STEP | CORTEXM_DHCSR_C_MASKINTS;
 
 	/* Disable interrupts while single stepping... */
 	if(step != priv->stepping) {

--- a/src/cortexm.c
+++ b/src/cortexm.c
@@ -256,6 +256,7 @@ cortexm_probe(struct target_s *target)
 
 	PROBE(stm32f1_probe);
 	PROBE(stm32f4_probe);
+	PROBE(stm32l0_probe);   /* STM32L0xx & STM32L1xx */
 	PROBE(stm32l1_probe);
 	PROBE(lpc11xx_probe);
 	PROBE(lpc43xx_probe);

--- a/src/include/cortexm.h
+++ b/src/include/cortexm.h
@@ -1,0 +1,130 @@
+#ifndef __CORTEXM_H
+#define __CORTEXM_H
+
+/* Private peripheral bus base address */
+#define CORTEXM_PPB_BASE	0xE0000000
+
+#define CORTEXM_SCS_BASE	(CORTEXM_PPB_BASE + 0xE000)
+
+#define CORTEXM_AIRCR		(CORTEXM_SCS_BASE + 0xD0C)
+#define CORTEXM_CFSR		(CORTEXM_SCS_BASE + 0xD28)
+#define CORTEXM_HFSR		(CORTEXM_SCS_BASE + 0xD2C)
+#define CORTEXM_DFSR		(CORTEXM_SCS_BASE + 0xD30)
+#define CORTEXM_CPACR		(CORTEXM_SCS_BASE + 0xD88)
+#define CORTEXM_DHCSR		(CORTEXM_SCS_BASE + 0xDF0)
+#define CORTEXM_DCRSR		(CORTEXM_SCS_BASE + 0xDF4)
+#define CORTEXM_DCRDR		(CORTEXM_SCS_BASE + 0xDF8)
+#define CORTEXM_DEMCR		(CORTEXM_SCS_BASE + 0xDFC)
+
+#define CORTEXM_FPB_BASE	(CORTEXM_PPB_BASE + 0x2000)
+
+/* ARM Literature uses FP_*, we use CORTEXM_FPB_* consistently */
+#define CORTEXM_FPB_CTRL	(CORTEXM_FPB_BASE + 0x000)
+#define CORTEXM_FPB_REMAP	(CORTEXM_FPB_BASE + 0x004)
+#define CORTEXM_FPB_COMP(i)	(CORTEXM_FPB_BASE + 0x008 + (4*(i)))
+
+#define CORTEXM_DWT_BASE	(CORTEXM_PPB_BASE + 0x1000)
+
+#define CORTEXM_DWT_CTRL	(CORTEXM_DWT_BASE + 0x000)
+#define CORTEXM_DWT_COMP(i)	(CORTEXM_DWT_BASE + 0x020 + (0x10*(i)))
+#define CORTEXM_DWT_MASK(i)	(CORTEXM_DWT_BASE + 0x024 + (0x10*(i)))
+#define CORTEXM_DWT_FUNC(i)	(CORTEXM_DWT_BASE + 0x028 + (0x10*(i)))
+
+/* Application Interrupt and Reset Control Register (AIRCR) */
+#define CORTEXM_AIRCR_VECTKEY		(0x05FA << 16)
+/* Bits 31:16 - Read as VECTKETSTAT, 0xFA05 */
+#define CORTEXM_AIRCR_ENDIANESS		(1 << 15)
+/* Bits 15:11 - Unused, reserved */
+#define CORTEXM_AIRCR_PRIGROUP		(7 << 8)
+/* Bits 7:3 - Unused, reserved */
+#define CORTEXM_AIRCR_SYSRESETREQ	(1 << 2)
+#define CORTEXM_AIRCR_VECTCLRACTIVE	(1 << 1)
+#define CORTEXM_AIRCR_VECTRESET		(1 << 0)
+
+/* HardFault Status Register (HFSR) */
+#define CORTEXM_HFSR_DEBUGEVT		(1 << 31)
+#define CORTEXM_HFSR_FORCED		(1 << 30)
+/* Bits 29:2 - Not specified */
+#define CORTEXM_HFSR_VECTTBL		(1 << 1)
+/* Bits 0 - Reserved */
+
+/* Debug Fault Status Register (DFSR) */
+/* Bits 31:5 - Reserved */
+#define CORTEXM_DFSR_RESETALL		0x1F
+#define CORTEXM_DFSR_EXTERNAL		(1 << 4)
+#define CORTEXM_DFSR_VCATCH		(1 << 3)
+#define CORTEXM_DFSR_DWTTRAP		(1 << 2)
+#define CORTEXM_DFSR_BKPT		(1 << 1)
+#define CORTEXM_DFSR_HALTED		(1 << 0)
+
+/* Debug Halting Control and Status Register (DHCSR) */
+/* This key must be written to bits 31:16 for write to take effect */
+#define CORTEXM_DHCSR_DBGKEY		0xA05F0000
+/* Bits 31:26 - Reserved */
+#define CORTEXM_DHCSR_S_RESET_ST	(1 << 25)
+#define CORTEXM_DHCSR_S_RETIRE_ST	(1 << 24)
+/* Bits 23:20 - Reserved */
+#define CORTEXM_DHCSR_S_LOCKUP		(1 << 19)
+#define CORTEXM_DHCSR_S_SLEEP		(1 << 18)
+#define CORTEXM_DHCSR_S_HALT		(1 << 17)
+#define CORTEXM_DHCSR_S_REGRDY		(1 << 16)
+/* Bits 15:6 - Reserved */
+#define CORTEXM_DHCSR_C_SNAPSTALL	(1 << 5)	/* v7m only */
+/* Bit 4 - Reserved */
+#define CORTEXM_DHCSR_C_MASKINTS	(1 << 3)
+#define CORTEXM_DHCSR_C_STEP		(1 << 2)
+#define CORTEXM_DHCSR_C_HALT		(1 << 1)
+#define CORTEXM_DHCSR_C_DEBUGEN		(1 << 0)
+
+/* Debug Core Register Selector Register (DCRSR) */
+#define CORTEXM_DCRSR_REGWnR		0x00010000
+#define CORTEXM_DCRSR_REGSEL_MASK	0x0000001F
+#define CORTEXM_DCRSR_REGSEL_XPSR	0x00000010
+#define CORTEXM_DCRSR_REGSEL_MSP	0x00000011
+#define CORTEXM_DCRSR_REGSEL_PSP	0x00000012
+
+/* Debug Exception and Monitor Control Register (DEMCR) */
+/* Bits 31:25 - Reserved */
+#define CORTEXM_DEMCR_TRCENA		(1 << 24)
+/* Bits 23:20 - Reserved */
+#define CORTEXM_DEMCR_MON_REQ		(1 << 19)	/* v7m only */
+#define CORTEXM_DEMCR_MON_STEP		(1 << 18)	/* v7m only */
+#define CORTEXM_DEMCR_VC_MON_PEND	(1 << 17)	/* v7m only */
+#define CORTEXM_DEMCR_VC_MON_EN		(1 << 16)	/* v7m only */
+/* Bits 15:11 - Reserved */
+#define CORTEXM_DEMCR_VC_HARDERR	(1 << 10)
+#define CORTEXM_DEMCR_VC_INTERR		(1 << 9)	/* v7m only */
+#define CORTEXM_DEMCR_VC_BUSERR		(1 << 8)	/* v7m only */
+#define CORTEXM_DEMCR_VC_STATERR	(1 << 7)	/* v7m only */
+#define CORTEXM_DEMCR_VC_CHKERR		(1 << 6)	/* v7m only */
+#define CORTEXM_DEMCR_VC_NOCPERR	(1 << 5)	/* v7m only */
+#define CORTEXM_DEMCR_VC_MMERR		(1 << 4)	/* v7m only */
+/* Bits 3:1 - Reserved */
+#define CORTEXM_DEMCR_VC_CORERESET	(1 << 0)
+
+/* Flash Patch and Breakpoint Control Register (FP_CTRL) */
+/* Bits 32:15 - Reserved */
+/* Bits 14:12 - NUM_CODE2 */	/* v7m only */
+/* Bits 11:8 - NUM_LIT */	/* v7m only */
+/* Bits 7:4 - NUM_CODE1 */
+/* Bits 3:2 - Unspecified */
+#define CORTEXM_FPB_CTRL_KEY		(1 << 1)
+#define CORTEXM_FPB_CTRL_ENABLE		(1 << 0)
+
+/* Data Watchpoint and Trace Mask Register (DWT_MASKx) */
+#define CORTEXM_DWT_MASK_BYTE		(0 << 0)
+#define CORTEXM_DWT_MASK_HALFWORD	(1 << 0)
+#define CORTEXM_DWT_MASK_WORD		(3 << 0)
+
+/* Data Watchpoint and Trace Function Register (DWT_FUNCTIONx) */
+#define CORTEXM_DWT_FUNC_MATCHED	(1 << 24)
+#define CORTEXM_DWT_FUNC_DATAVSIZE_WORD	(2 << 10)	/* v7m only */
+#define CORTEXM_DWT_FUNC_FUNC_READ	(5 << 0)
+#define CORTEXM_DWT_FUNC_FUNC_WRITE	(6 << 0)
+#define CORTEXM_DWT_FUNC_FUNC_ACCESS	(7 << 0)
+
+void cortexm_detach(struct target_s *target);
+void cortexm_halt_resume(struct target_s *target, bool step);
+
+#endif
+

--- a/src/include/stm32lx-nvm.h
+++ b/src/include/stm32lx-nvm.h
@@ -1,0 +1,230 @@
+/* @file stm32lx-nvm.h
+ *
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2014 Woollysoft
+ * Written by Marc Singer <elf@woollysoft.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined (STM32Lx_NVM_H_INCLUDED)
+#    define   STM32Lx_NVM_H_INCLUDED
+
+/* ----- Includes */
+
+#include <stdint.h>
+
+/* ----- Macros */
+
+/* ----- Types */
+
+enum {
+  STM32Lx_STUB_PHYS            = 0x20000000ul,
+  STM32Lx_STUB_INFO_PHYS       = 0x20000004ul,
+  STM32Lx_STUB_DATA_PHYS       = (0x20000000ul + 1024),
+  STM32Lx_STUB_DATA_MAX        = 1024,
+
+  STM32Lx_NVM_OPT_PHYS         = 0x1ff80000ul,
+  STM32Lx_NVM_EEPROM_PHYS      = 0x08080000ul,
+
+  STM32L0_NVM_PHYS             = 0x40022000ul,
+  STM32L0_NVM_PROG_PAGE_SIZE   = 128,
+  STM32L0_NVM_DATA_PAGE_SIZE   = 4,
+  STM32L0_NVM_OPT_SIZE         = 12,
+  STM32L0_NVM_EEPROM_SIZE      = 2*1024,
+
+  STM32L1_NVM_PHYS             = 0x40023c00ul,
+  STM32L1_NVM_PROG_PAGE_SIZE   = 256,
+  STM32L1_NVM_DATA_PAGE_SIZE   = 4,
+  STM32L1_NVM_OPT_SIZE         = 32,
+  STM32L1_NVM_EEPROM_SIZE      = 16*1024,
+
+  STM32Lx_NVM_PEKEY1           = 0x89abcdeful,
+  STM32Lx_NVM_PEKEY2           = 0x02030405ul,
+  STM32Lx_NVM_PRGKEY1          = 0x8c9daebful,
+  STM32Lx_NVM_PRGKEY2          = 0x13141516ul,
+  STM32Lx_NVM_OPTKEY1          = 0xfbead9c8ul,
+  STM32Lx_NVM_OPTKEY2          = 0x24252627ul,
+
+  STM32Lx_NVM_PECR_OBL_LAUNCH  = (1<<18),
+  STM32Lx_NVM_PECR_ERRIE       = (1<<17),
+  STM32Lx_NVM_PECR_EOPIE       = (1<<16),
+  STM32Lx_NVM_PECR_FPRG        = (1<<10),
+  STM32Lx_NVM_PECR_ERASE       = (1<< 9),
+  STM32Lx_NVM_PECR_FIX         = (1<< 8), /* FTDW */
+  STM32Lx_NVM_PECR_DATA        = (1<< 4),
+  STM32Lx_NVM_PECR_PROG        = (1<< 3),
+  STM32Lx_NVM_PECR_OPTLOCK     = (1<< 2),
+  STM32Lx_NVM_PECR_PRGLOCK     = (1<< 1),
+  STM32Lx_NVM_PECR_PELOCK      = (1<< 0),
+
+  STM32Lx_NVM_SR_FWWERR        = (1<<17),
+  STM32Lx_NVM_SR_NOTZEROERR    = (1<<16),
+  STM32Lx_NVM_SR_RDERR         = (1<<13),
+  STM32Lx_NVM_SR_OPTVER        = (1<<11),
+  STM32Lx_NVM_SR_SIZERR        = (1<<10),
+  STM32Lx_NVM_SR_PGAERR        = (1<<9),
+  STM32Lx_NVM_SR_WRPERR        = (1<<8),
+  STM32Lx_NVM_SR_READY         = (1<<3),
+  STM32Lx_NVM_SR_HWOFF         = (1<<2),
+  STM32Lx_NVM_SR_EOP           = (1<<1),
+  STM32Lx_NVM_SR_BSY           = (1<<0),
+  STM32Lx_NVM_SR_ERR_M         = (  STM32Lx_NVM_SR_WRPERR
+                                  | STM32Lx_NVM_SR_PGAERR
+                                  | STM32Lx_NVM_SR_SIZERR
+                                  | STM32Lx_NVM_SR_NOTZEROERR),
+
+  STM32L0_NVM_OPTR_BOOT1       = (1<<31),
+  STM32L0_NVM_OPTR_WDG_SW      = (1<<20),
+  STM32L0_NVM_OPTR_WPRMOD      = (1<<8),
+  STM32L0_NVM_OPTR_RDPROT_S    = (0),
+  STM32L0_NVM_OPTR_RDPROT_M    = (0xff),
+  STM32L0_NVM_OPTR_RDPROT_0    = (0xaa),
+  STM32L0_NVM_OPTR_RDPROT_2    = (0xcc),
+
+  STM32L1_NVM_OPTR_nBFB2       = (1<<23),
+  STM32L1_NVM_OPTR_nRST_STDBY  = (1<<22),
+  STM32L1_NVM_OPTR_nRST_STOP   = (1<<21),
+  STM32L1_NVM_OPTR_WDG_SW      = (1<<20),
+  STM32L1_NVM_OPTR_BOR_LEV_S   = (16),
+  STM32L1_NVM_OPTR_BOR_LEV_M   = (0xf),
+  STM32L1_NVM_OPTR_SPRMOD      = (1<<8),
+  STM32L1_NVM_OPTR_RDPROT_S    = (0),
+  STM32L1_NVM_OPTR_RDPROT_M    = (0xff),
+  STM32L1_NVM_OPTR_RDPROT_0    = (0xaa),
+  STM32L1_NVM_OPTR_RDPROT_2    = (0xcc),
+
+};
+
+#if defined (__cplusplus)
+
+namespace STM32 {
+  struct NVM {
+    volatile uint32_t acr;
+    volatile uint32_t pecr;
+    volatile uint32_t pdkeyr;
+    volatile uint32_t pkeyr;
+    volatile uint32_t prgkeyr;
+    volatile uint32_t optkeyr;
+    volatile uint32_t sr;
+    volatile uint32_t optr;
+    volatile uint32_t wrprot;
+
+    static constexpr uint32_t PKEY1   = 0x89abcdef;
+    static constexpr uint32_t PKEY2   = 0x02030405;
+    static constexpr uint32_t PRGKEY1 = 0x8c9daebf;
+    static constexpr uint32_t PRGKEY2 = 0x13141516;
+    static constexpr uint32_t OPTKEY1 = 0xfbead9c8;
+    static constexpr uint32_t OPTKEY2 = 0x24252627;
+    static constexpr uint32_t PDKEY1  = 0x04152637;
+    static constexpr uint32_t PDKEY2  = 0xfafbfcfd;
+  };
+
+  static_assert(sizeof (NVM) == 9*4, "NVM size error");
+
+  struct NVML1 {
+    volatile uint32_t acr;
+    volatile uint32_t pecr;
+    volatile uint32_t pdkeyr;
+    volatile uint32_t pekeyr;
+    volatile uint32_t prgkeyr;
+    volatile uint32_t optkeyr;
+    volatile uint32_t sr;
+    volatile uint32_t obr;
+    volatile uint32_t wrprot1;
+
+    static constexpr uint32_t PKEY1   = 0x89abcdef;
+    static constexpr uint32_t PKEY2   = 0x02030405;
+    static constexpr uint32_t PRGKEY1 = 0x8c9daebf;
+    static constexpr uint32_t PRGKEY2 = 0x13141516;
+    static constexpr uint32_t OPTKEY1 = 0xfbead9c8;
+    static constexpr uint32_t OPTKEY2 = 0x24252627;
+    static constexpr uint32_t PDKEY1  = 0x04152637;
+    static constexpr uint32_t PDKEY2  = 0xfafbfcfd;
+  };
+
+  static_assert(sizeof (NVML1) == 9*4, "NVML1 size error");
+}
+using   stm32lx_stub_pointer_t = uint32_t*;
+
+#define Nvm	(*reinterpret_cast<STM32::NVM*>(STM32L0_NVM_PHYS))
+#define NvmL1   (*reinterpret_cast<STM32::NVML1*>(STM32L1_NVM_PHYS))
+#define Info (*reinterpret_cast<stm32lx_nvm_stub_info*>(STM32Lx_STUB_INFO_PHYS))
+
+
+namespace {
+  inline __attribute((always_inline)) bool unlock () {
+    Nvm.pecr      = STM32Lx_NVM_PECR_PELOCK; // Lock to guarantee unlock
+    Nvm.pkeyr     = STM32::NVM::PKEY1;
+    Nvm.pkeyr     = STM32::NVM::PKEY2;
+    Nvm.prgkeyr   = STM32::NVM::PRGKEY1;
+    Nvm.prgkeyr   = STM32::NVM::PRGKEY2;
+    return !(Nvm.pecr & STM32Lx_NVM_PECR_PRGLOCK);
+  }
+  inline __attribute((always_inline)) void lock () {
+    Nvm.pecr      = STM32Lx_NVM_PECR_PELOCK; }
+
+  inline __attribute((always_inline)) bool unlock_l1 () {
+    NvmL1.pecr    = STM32Lx_NVM_PECR_PELOCK; // Lock to guarantee unlock
+    NvmL1.pekeyr  = STM32::NVML1::PKEY1;
+    NvmL1.pekeyr  = STM32::NVML1::PKEY2;
+    NvmL1.prgkeyr = STM32::NVML1::PRGKEY1;
+    NvmL1.prgkeyr = STM32::NVML1::PRGKEY2;
+    return !(Nvm.pecr & STM32Lx_NVM_PECR_PRGLOCK);
+  }
+  inline __attribute((always_inline)) void lock_l1 () {
+    Nvm.pecr      = STM32Lx_NVM_PECR_PELOCK; }
+}
+
+#else
+
+typedef uint32_t stm32lx_stub_pointer_t;
+
+struct stm32lx_nvm {
+  volatile uint32_t acr;
+  volatile uint32_t pecr;
+  volatile uint32_t pdkeyr;
+  volatile uint32_t pekeyr;
+  volatile uint32_t prgkeyr;
+  volatile uint32_t optkeyr;
+  volatile uint32_t sr;
+  volatile uint32_t optr;       /* or obr */
+  volatile uint32_t wrprot;     /* or wprot1 */
+};
+
+#define STM32Lx_NVM(p)		(*(struct stm32lx_nvm*) (p))
+#define STM32Lx_NVM_PECR(p)	((uint32_t) &STM32Lx_NVM(p).pecr)
+#define STM32Lx_NVM_PEKEYR(p)	((uint32_t) &STM32Lx_NVM(p).pekeyr)
+#define STM32Lx_NVM_PRGKEYR(p)	((uint32_t) &STM32Lx_NVM(p).prgkeyr)
+#define STM32Lx_NVM_OPTKEYR(p)	((uint32_t) &STM32Lx_NVM(p).optkeyr)
+#define STM32Lx_NVM_SR(p)	((uint32_t) &STM32Lx_NVM(p).sr)
+#define STM32Lx_NVM_OPTR(p)	((uint32_t) &STM32Lx_NVM(p).optr)
+
+#endif
+
+struct stm32lx_nvm_stub_info {
+  stm32lx_stub_pointer_t  destination;
+  int32_t		  size;
+  stm32lx_stub_pointer_t  source;
+  uint32_t                page_size;
+};
+
+/* ----- Globals */
+
+/* ----- Prototypes */
+
+
+
+#endif  /* STM32Lx_NVM_H_INCLUDED */

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -218,6 +218,7 @@ void target_add_commands(target *t, const struct command_s *cmds, const char *na
 bool cortexm_probe(struct target_s *target);
 bool stm32f1_probe(struct target_s *target);
 bool stm32f4_probe(struct target_s *target);
+bool stm32l0_probe(struct target_s *target);
 bool stm32l1_probe(struct target_s *target);
 bool lmi_probe(struct target_s *target);
 bool lpc11xx_probe(struct target_s *target);

--- a/src/samd20.c
+++ b/src/samd20.c
@@ -39,6 +39,7 @@
 #include "target.h"
 #include "command.h"
 #include "gdb_packet.h"
+#include "cortexm.h"
 
 static int samd20_flash_erase(struct target_s *target, uint32_t addr, int len);
 static int samd20_flash_write(struct target_s *target, uint32_t dest,
@@ -145,104 +146,6 @@ static const char samd20_xml_memory_map[] = "<?xml version=\"1.0\"?>"
 /* Component ID */
 #define SAMD20_CID_VALUE		0xB105100D
 
-#define CORTEXM_PPB_BASE	0xE0000000
-
-#define CORTEXM_SCS_BASE	(CORTEXM_PPB_BASE + 0xE000)
-
-#define CORTEXM_AIRCR		(CORTEXM_SCS_BASE + 0xD0C)
-#define CORTEXM_CFSR		(CORTEXM_SCS_BASE + 0xD28)
-#define CORTEXM_HFSR		(CORTEXM_SCS_BASE + 0xD2C)
-#define CORTEXM_DFSR		(CORTEXM_SCS_BASE + 0xD30)
-#define CORTEXM_CPACR		(CORTEXM_SCS_BASE + 0xD88)
-#define CORTEXM_DHCSR		(CORTEXM_SCS_BASE + 0xDF0)
-#define CORTEXM_DCRSR		(CORTEXM_SCS_BASE + 0xDF4)
-#define CORTEXM_DCRDR		(CORTEXM_SCS_BASE + 0xDF8)
-#define CORTEXM_DEMCR		(CORTEXM_SCS_BASE + 0xDFC)
-
-/* Application Interrupt and Reset Control Register (AIRCR) */
-#define CORTEXM_AIRCR_VECTKEY		(0x05FA << 16)
-/* Bits 31:16 - Read as VECTKETSTAT, 0xFA05 */
-#define CORTEXM_AIRCR_ENDIANESS		(1 << 15)
-/* Bits 15:11 - Unused, reserved */
-#define CORTEXM_AIRCR_PRIGROUP		(7 << 8)
-/* Bits 7:3 - Unused, reserved */
-#define CORTEXM_AIRCR_SYSRESETREQ	(1 << 2)
-#define CORTEXM_AIRCR_VECTCLRACTIVE	(1 << 1)
-#define CORTEXM_AIRCR_VECTRESET		(1 << 0)
-
-/* Debug Fault Status Register (DFSR) */
-/* Bits 31:5 - Reserved */
-#define CORTEXM_DFSR_RESETALL		0x1F
-#define CORTEXM_DFSR_EXTERNAL		(1 << 4)
-#define CORTEXM_DFSR_VCATCH		(1 << 3)
-#define CORTEXM_DFSR_DWTTRAP		(1 << 2)
-#define CORTEXM_DFSR_BKPT		(1 << 1)
-#define CORTEXM_DFSR_HALTED		(1 << 0)
-
-/* Debug Halting Control and Status Register (DHCSR) */
-/* This key must be written to bits 31:16 for write to take effect */
-#define CORTEXM_DHCSR_DBGKEY		0xA05F0000
-/* Bits 31:26 - Reserved */
-#define CORTEXM_DHCSR_S_RESET_ST	(1 << 25)
-#define CORTEXM_DHCSR_S_RETIRE_ST	(1 << 24)
-/* Bits 23:20 - Reserved */
-#define CORTEXM_DHCSR_S_LOCKUP		(1 << 19)
-#define CORTEXM_DHCSR_S_SLEEP		(1 << 18)
-#define CORTEXM_DHCSR_S_HALT		(1 << 17)
-#define CORTEXM_DHCSR_S_REGRDY		(1 << 16)
-/* Bits 15:6 - Reserved */
-#define CORTEXM_DHCSR_C_SNAPSTALL	(1 << 5)	/* v7m only */
-/* Bit 4 - Reserved */
-#define CORTEXM_DHCSR_C_MASKINTS	(1 << 3)
-#define CORTEXM_DHCSR_C_STEP		(1 << 2)
-#define CORTEXM_DHCSR_C_HALT		(1 << 1)
-#define CORTEXM_DHCSR_C_DEBUGEN		(1 << 0)
-
-
-/* -------------------------------------------------------------------------- */
-/* Cortex-M definitions for SAM D20 revision B fix                            */
-/* -------------------------------------------------------------------------- */
-
-#define CORTEXM_FPB_BASE	(CORTEXM_PPB_BASE + 0x2000)
-
-/* ARM Literature uses FP_*, we use CORTEXM_FPB_* consistently */
-#define CORTEXM_FPB_CTRL	(CORTEXM_FPB_BASE + 0x000)
-#define CORTEXM_FPB_REMAP	(CORTEXM_FPB_BASE + 0x004)
-#define CORTEXM_FPB_COMP(i)	(CORTEXM_FPB_BASE + 0x008 + (4*(i)))
-
-#define CORTEXM_DWT_BASE	(CORTEXM_PPB_BASE + 0x1000)
-
-#define CORTEXM_DWT_CTRL	(CORTEXM_DWT_BASE + 0x000)
-#define CORTEXM_DWT_COMP(i)	(CORTEXM_DWT_BASE + 0x020 + (0x10*(i)))
-#define CORTEXM_DWT_MASK(i)	(CORTEXM_DWT_BASE + 0x024 + (0x10*(i)))
-#define CORTEXM_DWT_FUNC(i)	(CORTEXM_DWT_BASE + 0x028 + (0x10*(i)))
-
-#define CORTEXM_MAX_WATCHPOINTS	4	/* architecture says up to 15, no implementation has > 4 */
-#define CORTEXM_MAX_BREAKPOINTS	6	/* architecture says up to 127, no implementation has > 6 */
-
-struct cortexm_priv {
-	bool stepping;
-	bool on_bkpt;
-	/* Watchpoint unit status */
-	struct wp_unit_s {
-		uint32_t addr;
-		uint8_t type;
-		uint8_t size;
-	} hw_watchpoint[CORTEXM_MAX_WATCHPOINTS];
-	unsigned hw_watchpoint_max;
-	/* Breakpoint unit status */
-	uint32_t hw_breakpoint[CORTEXM_MAX_BREAKPOINTS];
-	unsigned hw_breakpoint_max;
-	/* Copy of DEMCR for vector-catch */
-	uint32_t demcr;
-	/* Semihosting state */
-	uint32_t syscall;
-	uint32_t errno;
-	uint32_t byte_count;
-};
-
-
-
 /* Utility */
 #define MINIMUM(a,b)			((a < b) ? a : b)
 
@@ -340,19 +243,7 @@ static void
 samd20_revB_detach(struct target_s *target)
 {
 	ADIv5_AP_t *ap = adiv5_target_ap(target);
-	struct cortexm_priv *priv = ap->priv;
-	unsigned i;
-
-	/* Clear any stale breakpoints */
-	for(i = 0; i < priv->hw_breakpoint_max; i++)
-		adiv5_ap_mem_write(ap, CORTEXM_FPB_COMP(i), 0);
-
-	/* Clear any stale watchpoints */
-	for(i = 0; i < priv->hw_watchpoint_max; i++)
-		adiv5_ap_mem_write(ap, CORTEXM_DWT_FUNC(i), 0);
-
-	/* Disable debug */
-	adiv5_ap_mem_write(ap, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY);
+	cortexm_detach(target);
 
 	/* ---- Additional ---- */
 	/* Exit extended reset */
@@ -374,25 +265,7 @@ static void
 samd20_revB_halt_resume(struct target_s *target, bool step)
 {
 	ADIv5_AP_t *ap = adiv5_target_ap(target);
-	struct cortexm_priv *priv = ap->priv;
-	uint32_t dhcsr = CORTEXM_DHCSR_DBGKEY | CORTEXM_DHCSR_C_DEBUGEN;
-
-	if(step) dhcsr |= CORTEXM_DHCSR_C_STEP | CORTEXM_DHCSR_C_MASKINTS;
-
-	/* Disable interrupts while single stepping... */
-	if(step != priv->stepping) {
-		adiv5_ap_mem_write(ap, CORTEXM_DHCSR, dhcsr | CORTEXM_DHCSR_C_HALT);
-		priv->stepping = step;
-	}
-
-	if (priv->on_bkpt) {
-		uint32_t pc = target->pc_read(target);
-		if ((adiv5_ap_mem_read_halfword(ap, pc) & 0xFF00) == 0xBE00)
-			target->pc_write(target, pc + 2);
-	}
-
-	adiv5_ap_mem_write(ap, CORTEXM_DHCSR, dhcsr);
-	ap->dp->allow_timeout = true;
+	cortexm_halt_resume(target, step);
 
 	/* ---- Additional ---- */
 	/* Exit extended reset */

--- a/src/stm32l0.c
+++ b/src/stm32l0.c
@@ -1,0 +1,1080 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2014,2015 Marc Singer <elf@woollysoft.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Description
+   -----------
+
+   This is an implementation of the target-specific functions for the
+   STM32L0x[1] and STM32L1x[2] families of ST Microelectronics MCUs,
+   Cortex M0+ SOCs.  The NVM interface is substantially similar to the
+   STM32L1x parts.  This module is written to better generalize the
+   NVM interface and to provide more features.
+
+   [1] ST Microelectronics Document RM0377 (DocID025942), "Reference
+       manual for Ultra-low-power STM32L0x1 advanced ARM-based 32-bit
+       MCUs," April 2014.
+
+   [2] ST Microelectronics Document RM0038 (DocID15965, "..."Reference
+       manual for STM32L100xx, STM32L151xx, STM32L152xx and STM32L162xx
+       advanced ARM®-based 32-bit MCUs, " July 2014
+
+
+   NOTES
+   =====
+
+   o Stubbed and non-stubbed NVM operation functions.  The STM32L0xx
+     appears to behave differently from other STM32 cores.  When it
+     enters a fault state it will not exit this state without a
+     reset.  However, the reset will immediately enter a fault state
+     if program flash is erased.  When in this state, it will not
+     permit execution of code in RAM in the way that other cores
+     will.  Changing the PC to the start of RAM and single stepping
+     will immediately HardFault.
+
+     The stub functions can be both faster and simpler because they
+     have direct access to the MCU.  So, to permit stub operation in
+     the best circumstances, the NVM operation functions will check
+     the MCU state and either execute the stub or non-stub version
+     accordingly. The user can override stubs as well with a command
+     in case the detection feature fails.
+
+   o Erase would be more efficient if we checked for non-blank-ness
+     before initiating an erase.  This would have to be done in a stub
+     for efficiency.
+
+   o Mass erase broken.  The method for performing a mass erase is to
+     set the options for read protection, reload the option bytes, set
+     options for no protection, and then reload the option bytes
+     again.  The command fails because we lose contact with the target
+     when we perform the option byte reload.  For the time being, the
+     command is disabled.
+
+   o Errors.  We probably should clear SR errors immediately after
+     detecting them.  If we don't then we always must wait for the NVM
+     module to complete the last operation before we can start another.
+
+   o There are minor inconsistencies between the stm32l0 and the
+     stm32l1 in when handling NVM operations.
+
+     o When we erase or write individual words (not half-pages) on the
+       stm32l0, we set the PROG bit.  On the stm32l1 the PROG bit is
+       only set when erasing.  This  is not documented in the register
+       summaries, but in the functional quick reference.
+
+     o On the STM32L1xx, PECR can only be changed when the NVM
+       hardware is idle.  The STM32L0xx allows the PECR to be updated
+       while an operation is in progress.
+
+  0x1ff80000: 0x00aa 0xff55 OK
+  0x1ff80004: 0x8070 0x7f8f OK
+  0x1ff80008: 0x0000 0xffff OK
+  OPTR: 0x807000aa, RDPROT 0, WPRMOD 0, WDG_SW 1, BOOT1 1
+
+
+    Options code
+p *(int*)0x40022004 = 1
+p *(int*)0x4002200c = 0x89abcdef
+p *(int*)0x4002200c = 0x02030405
+p *(int*)0x40022014 = 0xfbead9c8
+p *(int*)0x40022014 = 0x24252627
+p *(int*)0x40022004 = 0x10
+x/4wx 0x40022000
+p *(int*)0x1ff80000 = 0xff5500aa
+
+  l1 program
+p *(int*)0x40023c04 = 1
+p *(int*)0x40023c0c = 0x89abcdef
+p *(int*)0x40023c0c = 0x02030405
+p *(int*)0x40023c10 = 0x8c9daebf
+p *(int*)0x40023c10 = 0x13141516
+
+
+p *(int*)0x40023c14 = 0xfbead9c8
+p *(int*)0x40023c14 = 0x24252627
+
+*/
+
+#define CONFIG_STM32L1          /* Include support for STM32L1 */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "general.h"
+#include "adiv5.h"
+#include "target.h"
+#include "command.h"
+
+#include "stm32lx-nvm.h"
+
+static int inhibit_stubs;
+
+static int stm32lx_nvm_erase (struct target_s* target,
+                              uint32_t addr, int len);
+static int stm32lx_nvm_write (struct target_s* target,
+                              uint32_t destination,
+                              const uint8_t* source,
+                              int size);
+
+static int stm32lx_nvm_prog_erase (struct target_s* target,
+                                   uint32_t addr, int len);
+static int stm32lx_nvm_prog_write (struct target_s* target,
+                                   uint32_t destination,
+                                   const uint8_t* source,
+                                   int size);
+
+static int stm32lx_nvm_prog_erase_stubbed (struct target_s* target,
+                                           uint32_t addr, int len);
+static int stm32lx_nvm_prog_write_stubbed (struct target_s* target,
+                                           uint32_t destination,
+                                           const uint8_t* source,
+                                           int size);
+
+static int stm32lx_nvm_data_erase (struct target_s* target,
+                                   uint32_t addr, int len);
+static int stm32lx_nvm_data_write (struct target_s* target,
+                                   uint32_t destination,
+                                   const uint8_t* source,
+                                   int size);
+
+//static bool stm32l0_cmd_erase_mass (target* t, int argc, char** argv);
+static bool stm32lx_cmd_option     (target* t, int argc, char** argv);
+static bool stm32lx_cmd_eeprom     (target* t, int argc, char** argv);
+//static bool stm32l0_cmd_reset      (target* t, int argc, char** argv);
+static bool stm32lx_cmd_stubs      (target* t, int argc, char** argv);
+
+static const struct command_s stm32lx_cmd_list[] = {
+  { "stubs",		(cmd_handler) stm32lx_cmd_stubs,
+    "Enable/disable NVM operation stubs" },
+//  { "erase_mass",	(cmd_handler) stm32l0_cmd_erase_mass,
+//    "Erase NVM flash and data" },
+//  { "reset",		(cmd_handler) stm32l0_cmd_reset, "Reset target" },
+  { "option",		(cmd_handler) stm32lx_cmd_option,
+    "Manipulate option bytes"},
+  { "eeprom",		(cmd_handler) stm32lx_cmd_eeprom,
+    "Manipulate EEPROM (NVM data) memory"},
+  { 0 },
+};
+
+enum {
+  STM32L0_DBGMCU_IDCODE_PHYS = 0x40015800,
+  STM32L1_DBGMCU_IDCODE_PHYS = 0xe0042000,
+};
+
+static const char stm32l0_driver_str[] = "STM32L0xx";
+
+static const char stm32l0_xml_memory_map[] = "<?xml version=\"1.0\"?>"
+/* "<!DOCTYPE memory-map "
+   "             PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
+   "                    \"http://sourceware.org/gdb/gdb-memory-map.dtd\">"*/
+	"<memory-map>"
+  /* Program flash; ranges up to 64KiB (0x10000). */
+	"  <memory type=\"flash\" start=\"0x08000000\" length=\"0x10000\">"
+	"    <property name=\"blocksize\">0x80</property>"
+	"  </memory>"
+  /* Data (EEPROM) NVRAM; ranges up to 2KiB (0x800). */
+	"  <memory type=\"flash\" start=\"0x08080000\" length=\"0x800\">"
+	"    <property name=\"blocksize\">0x4</property>"
+	"  </memory>"
+  /* SRAM; ranges up to 8KiB (0x2000). */
+	"  <memory type=\"ram\" start=\"0x20000000\" length=\"0x2000\"/>"
+	"</memory-map>";
+
+#if defined (CONFIG_STM32L1)
+static const char stm32l1_driver_str[] = "STM32L1xx+";
+
+static const char stm32l1_xml_memory_map[] = "<?xml version=\"1.0\"?>"
+/* "<!DOCTYPE memory-map "
+   "             PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
+   "                    \"http://sourceware.org/gdb/gdb-memory-map.dtd\">"*/
+	"<memory-map>"
+  /* Program flash; ranges from 32KiB to 512KiB (0x80000). */
+	"  <memory type=\"flash\" start=\"0x08000000\" length=\"0x80000\">"
+	"    <property name=\"blocksize\">0x100</property>"
+	"  </memory>"
+  /* Data (EEPROM) NVRAM; ranges from 2K to 16KiB (0x4000). */
+	"  <memory type=\"flash\" start=\"0x08080000\" length=\"0x4000\">"
+	"    <property name=\"blocksize\">0x4</property>"
+	"  </memory>"
+  /* SRAM; ranges from 4KiB to 80KiB (0x14000). */
+	"  <memory type=\"ram\" start=\"0x20000000\" length=\"0x14000\"/>"
+	"</memory-map>";
+#endif
+
+static const uint16_t stm32l0_nvm_prog_write_stub [] = {
+#include "../flashstub/stm32l05x-nvm-prog-write.stub"
+};
+
+static const uint16_t stm32l0_nvm_prog_erase_stub [] = {
+#include "../flashstub/stm32l05x-nvm-prog-erase.stub"
+};
+
+static uint32_t stm32lx_nvm_prog_page_size (struct target_s* target)
+{
+  switch (target->idcode) {
+  case 0x417:                   /* STM32L0xx */
+    return STM32L0_NVM_PROG_PAGE_SIZE;
+  default:                      /* STM32L1xx */
+    return STM32L1_NVM_PROG_PAGE_SIZE;
+  }
+}
+
+static bool stm32lx_is_stm32l1 (struct target_s* target)
+{
+  switch (target->idcode) {
+  case 0x417:                   /* STM32L0xx */
+    return false;
+  default:                      /* STM32L1xx */
+    return true;
+  }
+}
+
+static uint32_t stm32lx_nvm_eeprom_size (struct target_s* target)
+{
+  switch (target->idcode) {
+  case 0x417:                   /* STM32L0xx */
+    return STM32L0_NVM_EEPROM_SIZE;
+  default:                      /* STM32L1xx */
+    return STM32L1_NVM_EEPROM_SIZE;
+  }
+}
+
+static uint32_t stm32lx_nvm_phys (struct target_s* target)
+{
+  switch (target->idcode) {
+  case 0x417:                   /* STM32L0xx */
+    return STM32L0_NVM_PHYS;
+  default:                      /* STM32L1xx */
+    return STM32L1_NVM_PHYS;
+  }
+}
+
+static uint32_t stm32lx_nvm_data_page_size (struct target_s* target)
+{
+  switch (target->idcode) {
+  case 0x417:                   /* STM32L0xx */
+    return STM32L0_NVM_DATA_PAGE_SIZE;
+  default:                      /* STM32L1xx */
+    return STM32L1_NVM_DATA_PAGE_SIZE;
+  }
+}
+
+static uint32_t stm32lx_nvm_option_size (struct target_s* target)
+{
+  switch (target->idcode) {
+  case 0x417:                   /* STM32L0xx */
+    return STM32L0_NVM_OPT_SIZE;
+  default:                      /* STM32L1xx */
+    return STM32L1_NVM_OPT_SIZE;
+  }
+}
+
+/** Query MCU memory for an indication as to whether or not the
+    currently attached target is served by this module.  We detect the
+    STM32L0xx parts as well as the STM32L1xx's. */
+bool stm32l0_probe (struct target_s* target)
+{
+  uint32_t idcode;
+
+#if defined (CONFIG_STM32L1)
+
+  idcode = adiv5_ap_mem_read (adiv5_target_ap (target),
+                              STM32L1_DBGMCU_IDCODE_PHYS) & 0xfff;
+  switch (idcode) {
+  case 0x416:                   /* CAT. 1 device */
+  case 0x429:                   /* CAT. 2 device */
+  case 0x427:                   /* CAT. 3 device */
+  case 0x436:                   /* CAT. 4 device */
+  case 0x437:                   /* CAT. 5 device  */
+    target->idcode      = idcode;
+    target->driver      = stm32l1_driver_str;
+    target->xml_mem_map = stm32l1_xml_memory_map;
+    target->flash_erase = stm32lx_nvm_erase;
+    target->flash_write = stm32lx_nvm_write;
+    target_add_commands (target, stm32lx_cmd_list, "STM32L1x");
+    return true;
+  }
+#endif
+
+  idcode = adiv5_ap_mem_read (adiv5_target_ap (target),
+                              STM32L0_DBGMCU_IDCODE_PHYS) & 0xfff;
+  switch (idcode) {
+  default:
+    break;
+
+  case 0x417:                   /* STM32L0x[123] & probably others */
+    target->idcode      = idcode;
+    target->driver	= stm32l0_driver_str;
+    target->xml_mem_map = stm32l0_xml_memory_map;
+    target->flash_erase = stm32lx_nvm_erase;
+    target->flash_write = stm32lx_nvm_write;
+    target_add_commands (target, stm32lx_cmd_list, "STM32L0x");
+    return true;
+  }
+
+  return false;
+}
+
+/** Lock the NVM control registers preventing writes or erases. */
+static void stm32lx_nvm_lock (ADIv5_AP_t* ap, uint32_t nvm)
+{
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_PELOCK);
+}
+
+/** Unlock the NVM control registers for modifying program or
+    data flash.  Returns true if the unlock succeeds. */
+static bool stm32lx_nvm_prog_data_unlock (ADIv5_AP_t* ap, uint32_t nvm)
+{
+  /* Always lock first because that's the only way to know that the
+     unlock can succeed. */
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm),    STM32Lx_NVM_PECR_PELOCK);
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PEKEYR(nvm),  STM32Lx_NVM_PEKEY1);
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PEKEYR(nvm),  STM32Lx_NVM_PEKEY2);
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PRGKEYR(nvm), STM32Lx_NVM_PRGKEY1);
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PRGKEYR(nvm), STM32Lx_NVM_PRGKEY2);
+
+  return !(adiv5_ap_mem_read (ap, STM32Lx_NVM_PECR(nvm))
+           & STM32Lx_NVM_PECR_PRGLOCK);
+}
+
+
+/** Unlock the NVM control registers for modifying option bytes.
+    Returns true if the unlock succeeds. */
+static bool stm32lx_nvm_opt_unlock (ADIv5_AP_t* ap, uint32_t nvm)
+{
+  /* Always lock first because that's the only way to know that the
+     unlock can succeed. */
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm),    STM32Lx_NVM_PECR_PELOCK);
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PEKEYR(nvm),  STM32Lx_NVM_PEKEY1);
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PEKEYR(nvm),  STM32Lx_NVM_PEKEY2);
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_OPTKEYR(nvm), STM32Lx_NVM_OPTKEY1);
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_OPTKEYR(nvm), STM32Lx_NVM_OPTKEY2);
+
+  return !(adiv5_ap_mem_read (ap, STM32Lx_NVM_PECR(nvm))
+           & STM32Lx_NVM_PECR_OPTLOCK);
+}
+
+
+/** Erase a region of flash using a stub function.  This only works
+    when the MCU hasn't entered a fault state (see NOTES).  The flash
+    array is erased for all pages from addr to addr+len inclusive.
+    Only stm32l0xx is supported. */
+static int stm32lx_nvm_prog_erase_stubbed (struct target_s* target,
+                                           uint32_t addr, int size)
+{
+  struct stm32lx_nvm_stub_info info;
+
+  info.page_size = stm32lx_nvm_prog_page_size (target);
+
+  /* Load the stub */
+  target_mem_write_words (target, STM32Lx_STUB_PHYS,
+                          (void*) &stm32l0_nvm_prog_erase_stub[0],
+                          sizeof (stm32l0_nvm_prog_erase_stub));
+
+  /* Setup parameters */
+  info.destination = addr;
+  info.size        = size;
+
+  /* Copy parameters */
+  target_mem_write_words (target, STM32Lx_STUB_INFO_PHYS,
+                          (void*) &info, sizeof (info));
+
+  /* Execute stub */
+  target_pc_write (target, STM32Lx_STUB_PHYS);
+  if (target_check_error (target))
+    return -1;
+  target_halt_resume (target, 0);
+  while (!target_halt_wait (target))
+    ;
+  {
+    ADIv5_AP_t* ap     = adiv5_target_ap(target);
+    const uint32_t nvm = stm32lx_nvm_phys (target);
+    if (adiv5_ap_mem_read (ap, STM32Lx_NVM_SR(nvm)) & STM32Lx_NVM_SR_ERR_M)
+      return -1;
+  }
+
+  return 0;
+}
+
+
+/** Write to program flash using a stub function.  This only works
+    when the MCU hasn't entered a fault state.  Once the MCU faults,
+    this function will not succeed because the MCU will fault before
+    executing a single instruction in the stub. */
+static int stm32lx_nvm_prog_write_stubbed (struct target_s* target,
+                                           uint32_t destination,
+                                           const uint8_t* source,
+                                           int size)
+{
+  struct stm32lx_nvm_stub_info info;
+  const uint32_t nvm = stm32lx_nvm_phys (target);
+  const size_t page_size = stm32lx_nvm_prog_page_size (target);
+
+//  static int attempts;
+
+  /* We can't handle unaligned destination or non-word writes. */
+  /* *** FIXME: we should handle misaligned writes by padding with
+     *** zeros.  Probably, the only real time we'd see something
+     *** misaligned would be on a write to a final half-word.  Perhaps
+     *** this could be handled with the stub?  In fact, aligning the
+     *** start is going to be mandatory.  We will change the code to
+     *** cope with a trailing half-word. */
+  if ((destination & 3) || (size & 3))
+    return -1;
+
+//  if (attempts++)
+//    return 0;
+
+//  if (!stm32l0_nvm_prog_data_unlock (adiv5_target_ap (target)))
+//    return -1;
+
+  info.page_size = page_size;
+
+  /* Load the stub */
+  target_mem_write_words (target, STM32Lx_STUB_PHYS,
+                          (void*) &stm32l0_nvm_prog_write_stub[0],
+                          sizeof (stm32l0_nvm_prog_write_stub));
+
+  while (size > 0) {
+
+    /* Max transfer size is adjusted in the event that the
+       destination isn't half-page aligned.  This allows the
+       sub to write the first partial half-page and then
+       as many half-pages as will fit in the buffer. */
+    size_t max = STM32Lx_STUB_DATA_MAX
+      - (destination - (destination & ~(info.page_size/2 - 1)));
+    size_t cb = size;
+    if (cb > max)
+      cb = max;
+
+    /* Setup parameters */
+    info.source      = STM32Lx_STUB_DATA_PHYS;
+    info.destination = destination;
+    info.size        = cb;
+
+    /* Copy data to write to flash */
+    target_mem_write_words (target, info.source, (void*) source, info.size);
+
+    /* Move pointers early */
+    destination += cb;
+    source += cb;
+    size -= cb;
+
+    /* Copy parameters */
+    target_mem_write_words (target, STM32Lx_STUB_INFO_PHYS,
+                            (void*) &info, sizeof (info));
+
+    /* Execute stub */
+    target_pc_write (target, STM32Lx_STUB_PHYS);
+    if (target_check_error (target))
+      return -1;
+    target_halt_resume (target, 0);
+    while (!target_halt_wait (target))
+      ;
+
+    if (adiv5_ap_mem_read (adiv5_target_ap (target), STM32Lx_NVM_SR(nvm))
+        & STM32Lx_NVM_SR_ERR_M)
+      return -1;
+  }
+
+  return 0;
+}
+
+
+/** Erase a region of NVM for STM32Lx.  This is the lead function and
+    it will invoke an implementation, stubbed or not depending on the
+    options and the range of addresses. */
+static int stm32lx_nvm_erase (struct target_s* target, uint32_t addr, int size)
+{
+  if (addr >= STM32Lx_NVM_EEPROM_PHYS)
+    return stm32lx_nvm_data_erase (target, addr, size);
+
+  /* Use stub if not inhibited, the MCU is in a non-exceptonal state
+     and there is stub. */
+  volatile uint32_t regs[20];
+  target_regs_read (target, &regs);
+  if (inhibit_stubs || (regs[16] & 0xf) || stm32lx_is_stm32l1 (target))
+    return stm32lx_nvm_prog_erase (target, addr, size);
+
+  return stm32lx_nvm_prog_erase_stubbed (target, addr, size);
+}
+
+
+/** Write to a region on NVM for STM32L1xx.  This is the lead function
+    and it will ibvoke an implementation, stubbed or not depending on
+    the options and the range of addresses. */
+static int stm32lx_nvm_write (struct target_s* target,
+                              uint32_t destination,
+                              const uint8_t* source,
+                              int size)
+{
+  if (destination >= STM32Lx_NVM_EEPROM_PHYS)
+    return stm32lx_nvm_data_write (target, destination, source, size);
+
+  /* Skip stub if the MCU is in a questionable state or if the user
+     asks us to avoid stubs. */
+  volatile uint32_t regs[20];
+  target_regs_read (target, &regs);
+  if (inhibit_stubs || (regs[16] & 0xf) || stm32lx_is_stm32l1 (target))
+    return stm32lx_nvm_prog_write (target, destination, source, size);
+
+  return stm32lx_nvm_prog_write_stubbed (target, destination, source, size);
+}
+
+
+/** Erase a region of program flash using operations through the debug
+    interface.  This is slower than stubbed versions (see NOTES).  The
+    flash array is erased for all pages from addr to addr+len
+    inclusive.  NVM register file address chosen from target. */
+static int stm32lx_nvm_prog_erase (struct target_s* target,
+                                   uint32_t addr, int len)
+{
+  ADIv5_AP_t* ap = adiv5_target_ap (target);
+  const size_t page_size = stm32lx_nvm_prog_page_size (target);
+  const uint32_t nvm = stm32lx_nvm_phys (target);
+
+  /* Word align */
+  len += (addr & 3);
+  addr &= ~3;
+
+  if (!stm32lx_nvm_prog_data_unlock (ap, nvm))
+    return -1;
+
+  /* Flash page erase instruction */
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm),
+                      STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_PROG);
+
+  {
+    uint32_t pecr = adiv5_ap_mem_read (ap, STM32Lx_NVM_PECR (nvm));
+    if ((pecr & (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+        != (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+      return -1;
+  }
+
+  /* Busy wait? *** FIXME: remove? */
+  while (adiv5_ap_mem_read (ap, STM32Lx_NVM_SR(nvm))
+         & STM32Lx_NVM_SR_BSY)
+    if (target_check_error(target))
+      return -1;
+
+  /* Clear errors.  *** FIXME: this only works when we wait for the
+     NVM block to complete the last operation. */
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_SR (nvm), STM32Lx_NVM_SR_ERR_M);
+
+  while (len > 0) {
+    /* Write first word of page to 0 */
+    adiv5_ap_mem_write (ap, addr, 0);
+
+    len  -= page_size;
+    addr += page_size;
+  }
+
+  /* Disable further programming by locking PECR */
+  stm32lx_nvm_lock (ap, nvm);
+
+  /* Wait for completion or an error */
+  while (1) {
+    uint32_t sr = adiv5_ap_mem_read (ap, STM32Lx_NVM_SR(nvm));
+    if (target_check_error (target))
+      return -1;
+    if (sr & STM32Lx_NVM_SR_BSY)
+      continue;
+    if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP))
+      return -1;
+    break;
+  }
+
+  return 0;
+}
+
+
+/** Write to program flash using operations through the debug
+    interface.  This is slower than the stubbed write (see NOTES).
+    NVM register file address chosen from target. */
+static int stm32lx_nvm_prog_write (struct target_s* target,
+                                   uint32_t destination,
+                                   const uint8_t* source_8,
+                                   int size)
+{
+  ADIv5_AP_t* ap = adiv5_target_ap (target);
+  const uint32_t nvm = stm32lx_nvm_phys (target);
+  const bool is_stm32l1 = stm32lx_is_stm32l1 (target);
+
+  /* We can only handle word aligned writes and even word-multiple
+     ranges.  The stm32l0 cannot perform anything smaller than a word
+     write due to the ECC bits. */
+  if ((destination & 3) || (size & 3))
+    return -1;
+
+  if (!stm32lx_nvm_prog_data_unlock (ap, nvm))
+    return -1;
+
+  const size_t half_page_size = stm32lx_nvm_prog_page_size (target)/2;
+  uint32_t* source = (uint32_t*) source_8;
+
+  while (size > 0) {
+
+    /* Wait for BSY to clear because we cannot write the PECR until
+       the previous operation completes on STM32L1xx. */
+    while (adiv5_ap_mem_read (ap, STM32Lx_NVM_SR(nvm)) & STM32Lx_NVM_SR_BSY)
+      if (target_check_error(target)) {
+        return -1;
+      }
+
+    // Either we're not half-page aligned or we have less than a half
+    // page to write
+    if (size < half_page_size || (destination & (half_page_size - 1))) {
+      adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm),
+                          is_stm32l1 ? 0 : STM32Lx_NVM_PECR_PROG);
+      size_t c = half_page_size - (destination & (half_page_size - 1));
+
+      if (c > size)
+        c = size;
+      size -= c;
+
+      target_mem_write_words (target, destination, source, c);
+      source += c/4;
+      destination += c;
+    }
+    // Or we are writing a half-page(s)
+    else {
+      adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR (nvm),
+                          STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_FPRG);
+
+      size_t c = size & ~(half_page_size - 1);
+      size -= c;
+      target_mem_write_words (target, destination, source, c);
+      source += c/4;
+      destination += c;
+    }
+  }
+
+  /* Disable further programming by locking PECR */
+  stm32lx_nvm_lock (ap, nvm);
+
+  /* Wait for completion or an error */
+  while (1) {
+    uint32_t sr = adiv5_ap_mem_read (ap, STM32Lx_NVM_SR (nvm));
+    if (target_check_error (target)) {
+      return -1;
+    }
+    if (sr & STM32Lx_NVM_SR_BSY)
+      continue;
+    if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP)) {
+      return -1;
+    }
+    break;
+  }
+
+  return 0;
+}
+
+
+/** Erase a region of data flash using operations through the debug
+    interface .  The flash is erased for all pages from addr to
+    addr+len, inclusive, on a word boundary.  NVM register file
+    address chosen from target. */
+static int stm32lx_nvm_data_erase (struct target_s* target,
+                                   uint32_t addr, int len)
+{
+  ADIv5_AP_t* ap = adiv5_target_ap (target);
+  const size_t page_size = stm32lx_nvm_data_page_size (target);
+  const uint32_t nvm = stm32lx_nvm_phys (target);
+
+  /* Word align */
+  len += (addr & 3);
+  addr &= ~3;
+
+  if (!stm32lx_nvm_prog_data_unlock (ap, nvm))
+    return -1;
+
+  /* Flash data erase instruction */
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm),
+                      STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA);
+
+  {
+    uint32_t pecr = adiv5_ap_mem_read (ap, STM32Lx_NVM_PECR(nvm));
+    if ((pecr & (STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA))
+        != (STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA))
+      return -1;
+  }
+
+  while (len > 0) {
+    /* Write first word of page to 0 */
+    adiv5_ap_mem_write (ap, addr, 0);
+
+    len  -= page_size;
+    addr += page_size;
+  }
+
+  /* Disable further programming by locking PECR */
+  stm32lx_nvm_lock (ap, nvm);
+
+  /* Wait for completion or an error */
+  while (1) {
+    uint32_t sr = adiv5_ap_mem_read (ap, STM32Lx_NVM_SR (nvm));
+    if (target_check_error (target))
+      return -1;
+    if (sr & STM32Lx_NVM_SR_BSY)
+      continue;
+    if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP))
+      return -1;
+    break;
+  }
+
+  return 0;
+}
+
+
+/** Write to data flash using operations through the debug interface.
+    NVM register file address chosen from target.
+
+    *** FIXME: need to make this work with writing a single byte as
+    well as words. */
+static int stm32lx_nvm_data_write (struct target_s* target,
+                                   uint32_t destination,
+                                   const uint8_t* source_8,
+                                   int size)
+{
+  ADIv5_AP_t* ap = adiv5_target_ap (target);
+  const uint32_t nvm = stm32lx_nvm_phys (target);
+  const bool is_stm32l1 = stm32lx_is_stm32l1 (target);
+
+  /* *** FIXME: need to make this work with writing a single byte. */
+  if ((destination & 3) || (size & 3))
+    return -1;
+
+  if (!stm32lx_nvm_prog_data_unlock (ap, nvm))
+    return -1;
+
+  uint32_t* source = (uint32_t*) source_8;
+
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm),
+                      is_stm32l1 ? 0 : STM32Lx_NVM_PECR_DATA);
+
+  while (size) {
+    size -= 4;
+    uint32_t v = *source++;
+    adiv5_ap_mem_write (ap, destination, v);
+    destination += 4;
+
+    if (target_check_error (target))
+      return -1;
+  }
+
+  /* Disable further programming by locking PECR */
+  stm32lx_nvm_lock (ap, nvm);
+
+  /* Wait for completion or an error */
+  while (1) {
+    uint32_t sr = adiv5_ap_mem_read (ap, STM32Lx_NVM_SR(nvm));
+    if (target_check_error (target))
+      return -1;
+    if (sr & STM32Lx_NVM_SR_BSY)
+      continue;
+    if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP))
+      return -1;
+    break;
+  }
+
+  return 0;
+}
+
+
+/** Write one option word.  The address is the physical address of the
+    word and the value is a complete word value.  The caller is
+    responsible for making sure that the value satisfies the proper
+    format where the upper 16 bits are the 1s complement of the lower
+    16 bits.  The funtion returns when the operation is complete.
+    The return value is true if the write succeeded. */
+static bool stm32lx_option_write (target *t, uint32_t address, uint32_t value)
+{
+  ADIv5_AP_t*    ap  = adiv5_target_ap(t);
+  const uint32_t nvm = stm32lx_nvm_phys (t);
+
+  /* Erase and program option in one go. */
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_FIX);
+  adiv5_ap_mem_write (ap, address, value);
+
+  uint32_t sr;
+  do {
+    sr = adiv5_ap_mem_read (ap, STM32Lx_NVM_SR(nvm));
+  } while (sr & STM32Lx_NVM_SR_BSY);
+
+  return !(sr & STM32Lx_NVM_SR_ERR_M);
+}
+
+/** Write one eeprom value.  This version is more flexible than that
+    bulk version used for writing data from the executable file.  The
+    address is the physical address of the word and the value is a
+    complete word value.  The funtion returns when the operation is
+    complete.  The return value is true if the write succeeded.
+    FWIW, byte writing isn't supported because the adiv5 layer
+    doesn't support byte-level operations. */
+static bool stm32lx_eeprom_write (target *t, uint32_t address,
+                                  size_t cb, uint32_t value)
+{
+  ADIv5_AP_t*    ap         = adiv5_target_ap(t);
+  const uint32_t nvm        = stm32lx_nvm_phys (t);
+  const bool     is_stm32l1 = stm32lx_is_stm32l1 (t);
+
+  /* Clear errors. */
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_SR (nvm), STM32Lx_NVM_SR_ERR_M);
+
+  /* Erase and program option in one go. */
+  adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm),
+                      (is_stm32l1 ? 0 : STM32Lx_NVM_PECR_DATA)
+                      | STM32Lx_NVM_PECR_FIX);
+  if (cb == 4)
+    adiv5_ap_mem_write (ap, address, value);
+  else if (cb == 2)
+    adiv5_ap_mem_write_halfword (ap, address, value);
+  else
+    return false;
+
+  uint32_t sr;
+  do {
+    sr = adiv5_ap_mem_read (ap, STM32Lx_NVM_SR(nvm));
+  } while (sr & STM32Lx_NVM_SR_BSY);
+
+  return !(sr & STM32Lx_NVM_SR_ERR_M);
+}
+
+static bool stm32lx_cmd_stubs (target* t,
+                               int argc, char** argv)
+{
+  if (argc == 1) {
+    gdb_out ("usage: mon stubs [enable/disable]\n");
+  }
+  else if (argc == 2) {
+    size_t cb = strlen (argv[1]);
+    if (!strncasecmp (argv[1], "enable", cb))
+      inhibit_stubs = 0;
+    if (!strncasecmp (argv[1], "disable", cb))
+      inhibit_stubs = 1;
+  }
+  gdb_outf ("stubs: %sabled\n", inhibit_stubs ? "dis" : "en");
+
+  return true;
+}
+
+#if 0
+static bool stm32l0_cmd_erase_mass (target* t, int argc , char** argv)
+{
+  ADIv5_AP_t* ap = adiv5_target_ap (t);
+
+  stm32lx_nvm_opt_unlock (ap);
+
+  stm32l0_option_write (t, 0x1ff80000, 0xffff0000);
+  adiv5_ap_mem_write (ap, STM32L0_NVM_PECR, STM32L0_NVM_PECR_OBL_LAUNCH);
+  stm32l0_option_write (t, 0x1ff80000, 0xff5500aa);
+  adiv5_ap_mem_write (ap, STM32L0_NVM_PECR, STM32L0_NVM_PECR_OBL_LAUNCH);
+
+  uint32_t sr;
+  do {
+    sr = adiv5_ap_mem_read (ap, STM32L0_NVM_SR);
+  } while (sr & STM32L0_NVM_SR_BSY);
+
+  stm32l0_nvm_lock (ap);
+  return true;
+}
+#endif
+
+#if 0
+static bool stm32l0_cmd_reset (target* t, int argc, char** argv)
+{
+  gdb_out ("Resetting target\n");
+  target_reset (t);
+
+  return true;
+}
+#endif
+
+static bool stm32lx_cmd_option (target* t, int argc, char** argv)
+{
+  ADIv5_AP_t*    ap       = adiv5_target_ap (t);
+  const uint32_t nvm      = stm32lx_nvm_phys (t);
+  const size_t   opt_size = stm32lx_nvm_option_size (t);
+
+  if (!stm32lx_nvm_opt_unlock (ap, nvm)) {
+    gdb_out ("unable to unlock NVM option bytes\n");
+    return true;
+  }
+
+  size_t cb = strlen (argv[1]);
+
+  if (argc == 2 && !strncasecmp (argv[1], "obl_launch", cb)) {
+    adiv5_ap_mem_write (ap, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_OBL_LAUNCH);
+  }
+  else if (argc == 4 && !strncasecmp (argv[1], "raw", cb)) {
+    uint32_t addr = strtoul (argv[2], NULL, 0);
+    uint32_t val  = strtoul (argv[3], NULL, 0);
+    gdb_outf ("raw %08x <- %08x\n", addr, val);
+    if (   addr <  STM32Lx_NVM_OPT_PHYS
+        || addr >= STM32Lx_NVM_OPT_PHYS + opt_size
+        || (addr & 3))
+      goto usage;
+    if (!stm32lx_option_write (t, addr, val))
+      gdb_out ("option write failed\n");
+  }
+  else if (argc == 4 && !strncasecmp (argv[1], "write", cb)) {
+    uint32_t addr = strtoul (argv[2], NULL, 0);
+    uint32_t val  = strtoul (argv[3], NULL, 0);
+    val = (val & 0xffff) | ((~val & 0xffff) << 16);
+    gdb_outf ("write %08x <- %08x\n", addr, val);
+    if (   addr <  STM32Lx_NVM_OPT_PHYS
+        || addr >= STM32Lx_NVM_OPT_PHYS + opt_size
+        || (addr & 3))
+      goto usage;
+    if (!stm32lx_option_write (t, addr, val))
+      gdb_out ("option write failed\n");
+  }
+  else if (argc == 2 && !strncasecmp (argv[1], "show", cb))
+    ;
+  else
+    goto usage;
+
+  /* Report the current option values */
+  for (int i = 0; i < opt_size; i += sizeof (uint32_t)) {
+    uint32_t addr = STM32Lx_NVM_OPT_PHYS + i;
+    uint32_t val = adiv5_ap_mem_read (ap, addr);
+    gdb_outf ("0x%08x: 0x%04x 0x%04x %s\n",
+              addr, val & 0xffff, (val >> 16) & 0xffff,
+              ((val & 0xffff) == ((~val >> 16) & 0xffff)) ? "OK" : "ERR");
+  }
+  if (stm32lx_is_stm32l1 (t)) {
+    uint32_t optr   = adiv5_ap_mem_read (ap, STM32Lx_NVM_OPTR(nvm));
+    uint8_t  rdprot = (optr >> STM32L1_NVM_OPTR_RDPROT_S)
+      & STM32L1_NVM_OPTR_RDPROT_M;
+    if (rdprot == STM32L1_NVM_OPTR_RDPROT_0)
+      rdprot = 0;
+    else if (rdprot == STM32L1_NVM_OPTR_RDPROT_2)
+      rdprot = 2;
+    else
+      rdprot = 1;
+    gdb_outf ("OPTR: 0x%08x, RDPRT %d, SPRMD %d, "
+              "BOR %d, WDG_SW %d, nRST_STP %d, nRST_STBY %d, nBFB2 %d\n",
+              optr, rdprot,
+              (optr &  STM32L1_NVM_OPTR_SPRMOD)     ? 1 : 0,
+              (optr >> STM32L1_NVM_OPTR_BOR_LEV_S) & STM32L1_NVM_OPTR_BOR_LEV_M,
+              (optr &  STM32L1_NVM_OPTR_WDG_SW)     ? 1 : 0,
+              (optr &  STM32L1_NVM_OPTR_nRST_STOP)  ? 1 : 0,
+              (optr &  STM32L1_NVM_OPTR_nRST_STDBY) ? 1 : 0,
+              (optr &  STM32L1_NVM_OPTR_nBFB2)      ? 1 : 0);
+  }
+  else {
+    uint32_t optr   = adiv5_ap_mem_read (ap, STM32Lx_NVM_OPTR(nvm));
+    uint8_t  rdprot = (optr >> STM32L0_NVM_OPTR_RDPROT_S)
+      & STM32L0_NVM_OPTR_RDPROT_M;
+    if (rdprot == STM32L0_NVM_OPTR_RDPROT_0)
+      rdprot = 0;
+    else if (rdprot == STM32L0_NVM_OPTR_RDPROT_2)
+      rdprot = 2;
+    else
+      rdprot = 1;
+    gdb_outf ("OPTR: 0x%08x, RDPROT %d, WPRMOD %d, WDG_SW %d, BOOT1 %d\n",
+              optr, rdprot,
+              (optr & STM32L0_NVM_OPTR_WPRMOD) ? 1 : 0,
+              (optr & STM32L0_NVM_OPTR_WDG_SW) ? 1 : 0,
+              (optr & STM32L0_NVM_OPTR_BOOT1)  ? 1 : 0);
+  }
+
+  goto done;
+
+ usage:
+  gdb_out ("usage: monitor option [ARGS]\n");
+  gdb_out ("  show                   - Show options in NVM and as loaded\n");
+  gdb_out ("  obl_launch             - Reload options from NVM\n");
+  gdb_out ("  write <addr> <value16> - Set option half-word; "
+           "complement computed\n");
+  gdb_out ("  raw <addr> <value32>   - Set option word\n");
+  gdb_outf ("The value of <addr> must be word aligned and from 0x%08x "
+            "to +0x%x\n",
+            STM32Lx_NVM_OPT_PHYS,
+            STM32Lx_NVM_OPT_PHYS + opt_size - sizeof (uint32_t));
+
+ done:
+  stm32lx_nvm_lock (ap, nvm);
+  return true;
+}
+
+
+static bool stm32lx_cmd_eeprom (target* t, int argc, char** argv)
+{
+  ADIv5_AP_t*    ap  = adiv5_target_ap (t);
+  const uint32_t nvm = stm32lx_nvm_phys (t);
+
+  if (!stm32lx_nvm_prog_data_unlock (ap, nvm)) {
+    gdb_out ("unable to unlock EEPROM\n");
+    return true;
+  }
+
+  size_t cb = strlen (argv[1]);
+
+  if (argc == 4) {
+    uint32_t addr = strtoul (argv[2], NULL, 0);
+    uint32_t val  = strtoul (argv[3], NULL, 0);
+
+    if (   addr <  STM32Lx_NVM_EEPROM_PHYS
+        || addr >= STM32Lx_NVM_EEPROM_PHYS + stm32lx_nvm_eeprom_size (t))
+      goto usage;
+
+#if 0
+    if (!strncasecmp (argv[1], "byte", cb)) {
+      gdb_outf ("write byte 0x%08x <- 0x%08x\n", addr, val);
+      if (!stm32l0_eeprom_write (t, addr, 1, val))
+        gdb_out ("eeprom write failed\n");
+    } else
+#endif
+      if (!strncasecmp (argv[1], "halfword", cb)) {
+        val &= 0xffff;
+        gdb_outf ("write halfword 0x%08x <- 0x%04x\n", addr, val);
+        if (addr & 1)
+          goto usage;
+        if (!stm32lx_eeprom_write (t, addr, 2, val))
+          gdb_out ("eeprom write failed\n");
+      } else if (!strncasecmp (argv[1], "word", cb)) {
+        gdb_outf ("write word 0x%08x <- 0x%08x\n", addr, val);
+        if (addr & 3)
+          goto usage;
+        if (!stm32lx_eeprom_write (t, addr, 4, val))
+          gdb_out ("eeprom write failed\n");
+      }
+      else
+        goto usage;
+  }
+  else
+    goto usage;
+
+  goto done;
+
+ usage:
+  gdb_out ("usage: monitor eeprom [ARGS]\n");
+//  gdb_out ("  byte     <addr> <value8>  - Write a byte\n");
+  gdb_out ("  halfword <addr> <value16> - Write a half-word\n");
+  gdb_out ("  word     <addr> <value32> - Write a word\n");
+  gdb_outf ("The value of <addr> must in the interval [0x%08x, 0x%x)\n",
+            STM32Lx_NVM_EEPROM_PHYS,
+            STM32Lx_NVM_EEPROM_PHYS
+            + stm32lx_nvm_eeprom_size (t));
+
+ done:
+  stm32lx_nvm_lock (ap, nvm);
+  return true;
+}


### PR DESCRIPTION
STM32L0 and STM32L1 combined platform support.  Includes methods for write/erase of EEPROM and monitor commands for EEPROM and options.  This implementation would replace the existing stm32l1 code.