### PR TITLE
Exceptions minor cleanup and stlink

### DIFF
--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -191,6 +191,8 @@ int platform_init(void);
 void morse(const char *msg, char repeat);
 const char *platform_target_voltage(void);
 int platform_hwversion(void);
+void platform_set_timeout(uint32_t ms);
+bool platform_timeout_expired(void);
 void platform_delay(uint32_t delay);
 
 /* <cdcacm.c> */

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -131,10 +131,20 @@ int platform_init(void)
 	return 0;
 }
 
+void platform_set_timeout(uint32_t ms)
+{
+	timeout_counter = ms / 100;
+}
+
+bool platform_timeout_expired(void)
+{
+	return timeout_counter == 0;
+}
+
 void platform_delay(uint32_t delay)
 {
-	timeout_counter = delay;
-	while (timeout_counter);
+	platform_set_timeout(delay);
+	while (!platform_timeout_expired());
 }
 
 void platform_srst_set_val(bool assert)

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -156,6 +156,7 @@ extern uint16_t led_idle_run;
 #define SET_RUN_STATE(state)	{running_status = (state);}
 #define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, led_idle_run, state);}
 
+#include "target.h"
 #define PLATFORM_SET_FATAL_ERROR_RECOVERY()	{setjmp(fatal_error_jmpbuf);}
 #define PLATFORM_FATAL_ERROR(error)	do { 		\
 	if(running_status) gdb_putpacketz("X1D");	\
@@ -168,6 +169,8 @@ extern uint16_t led_idle_run;
 int platform_init(void);
 void morse(const char *msg, char repeat);
 const char *platform_target_voltage(void);
+void platform_set_timeout(uint32_t ms);
+bool platform_timeout_expired(void);
 void platform_delay(uint32_t delay);
 void platform_srst_set_val(bool assert);
 
@@ -203,10 +206,10 @@ static inline uint16_t _gpio_get(uint32_t gpioport, uint16_t gpios)
 	return (uint16_t)GPIO_IDR(gpioport) & gpios;
 }
 #define gpio_get _gpio_get
-#endif
-
-#endif
+#endif /* INLINE_GPIO */
 
 void disconnect_usb(void);
 void assert_boot_pin(void);
+void setup_vbus_irq(void);
 
+#endif /* __PLATFORM_H */


### PR DESCRIPTION
This pull request contains minor improvements, and ports the changes to the stlink probe platform.

I have tested it on the stm32f4-discovery board, using the [stm32f4 timer example](https://github.com/libopencm3/libopencm3-examples/tree/master/examples/stm32/f4/stm32f4-discovery/timer), that uses __WFI in the main loop.

It is able to swdp_scan and attach to the target, this was not working all the time before. Now it seems to be quite reliable. I also tested the behavior when stuck in __WFI (disabled the interrupt in the example). It correctly points out that the swdp_scan failed due to timeout and that it might be due to WFI.

So far so good, will continue using this firmware and see how things go. :)