### PR TITLE
SAM4S: Erase flash in 8K instead of 16K chunks.

### DIFF
--- a/src/sam3x.c
+++ b/src/sam3x.c
@@ -291,26 +291,27 @@ static int sam3x_flash_erase(struct target_s *target, uint32_t addr, int len)
 	uint32_t base = sam3x_flash_base(target, addr, &offset);
 
 	/* The SAM4S is the only supported device with a page erase command.
-	 * Erasing is done in 16-page chunks. arg[15:2] contains the page
-	 * number and arg[1:0] contains 0x2, indicating 16-page chunks.
+	 * Erasing is done in 8-page chunks. arg[15:2] contains the page
+	 * number and arg[1:0] contains 0x1, indicating 8-page chunks.
 	 */
 	if (strcmp(target->driver, "Atmel SAM4S") == 0) {
 		unsigned chunk = offset / SAM4_PAGE_SIZE;
-		/* Fail if the start address is not 16-page-aligned. */
-		if (chunk % 16 != 0)
+
+		/* Fail if the start address is not 8-page-aligned. */
+		if (chunk % 8 != 0)
 			return -1;
 
-		/* Note that the length might not be a multiple of 16 pages.
+		/* Note that the length might not be a multiple of 8 pages.
 		 * In this case, we will erase a few extra pages at the end.
 		 */
 		while (len > 0) {
-			int16_t arg = (chunk << 2) | 0x2;
+			int16_t arg = chunk | 0x1;
 			if(sam3x_flash_cmd(target, base, EEFC_FCR_FCMD_EPA, arg))
 				return -1;
 
-			len -= SAM4_PAGE_SIZE * 16;
-			addr += SAM4_PAGE_SIZE * 16;
-			chunk += 16;
+			len -= SAM4_PAGE_SIZE * 8;
+			addr += SAM4_PAGE_SIZE * 8;
+			chunk += 8;
 		}
 
 		return 0;


### PR DESCRIPTION
This pull request (1) changes SAM4S flash erases to use 8 page chunks instead of 16 page chunks, and (2) corrects a bug in the generation of the FARG field for SAM4S flash erases.

(1) This issue is due to an error in the SAM4S datasheet. Table 20-4 states that 16 page erases may be used on all sectors, but buried in section 8.1.3.1 is a note that only 8 page erases are guaranteed to work in sectors 0 and 1.

(2) FARG[15:2] is not supposed to be shifted left by two bits. This bug was masked by the fact that an invalid 16 page erase on sector 0 also erased sectors 1-3.

I've been testing this change for more than a month now, so I am confident that there are no more SAM4S flash erase issues lurking within.

Cheers,
Dave