### PR TITLE
Cleaner exception handling.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,7 @@ SRC =			\
 	command.c	\
 	cortexm.c	\
 	crc32.c		\
+	exception.c	\
 	gdb_if.c	\
 	gdb_main.c	\
 	gdb_packet.c	\

--- a/src/adiv5_jtagdp.c
+++ b/src/adiv5_jtagdp.c
@@ -91,8 +91,8 @@ static uint32_t adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 		ack = response & 0x07;
 	} while(--tries && (ack == JTAGDP_ACK_WAIT));
 
-	if (dp->allow_timeout && (ack == JTAGDP_ACK_WAIT))
-		return 0;
+	if (ack == JTAGDP_ACK_WAIT)
+		raise_exception(EXCEPTION_TIMEOUT, "JTAG-DP ACK timeout");
 
 	if((ack != JTAGDP_ACK_OK))
 		raise_exception(EXCEPTION_ERROR, "JTAG-DP invalid ACK");

--- a/src/adiv5_jtagdp.c
+++ b/src/adiv5_jtagdp.c
@@ -85,11 +85,11 @@ static uint32_t adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 
 	jtag_dev_write_ir(dp->dev, APnDP ? IR_APACC : IR_DPACC);
 
-	int tries = 1000;
+	platform_timeout_set(2000);
 	do {
 		jtag_dev_shift_dr(dp->dev, (uint8_t*)&response, (uint8_t*)&request, 35);
 		ack = response & 0x07;
-	} while(--tries && (ack == JTAGDP_ACK_WAIT));
+	} while(!platform_timeout_is_expired() && (ack == JTAGDP_ACK_WAIT));
 
 	if (ack == JTAGDP_ACK_WAIT)
 		raise_exception(EXCEPTION_TIMEOUT, "JTAG-DP ACK timeout");

--- a/src/adiv5_jtagdp.c
+++ b/src/adiv5_jtagdp.c
@@ -23,6 +23,7 @@
  */
 
 #include "general.h"
+#include "exception.h"
 #include "adiv5.h"
 #include "jtag_scan.h"
 #include "jtagtap.h"
@@ -93,10 +94,8 @@ static uint32_t adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 	if (dp->allow_timeout && (ack == JTAGDP_ACK_WAIT))
 		return 0;
 
-	if((ack != JTAGDP_ACK_OK)) {
-		/* Fatal error if invalid ACK response */
-		PLATFORM_FATAL_ERROR(1);
-	}
+	if((ack != JTAGDP_ACK_OK))
+		raise_exception(EXCEPTION_ERROR, "JTAG-DP invalid ACK");
 
 	return (uint32_t)(response >> 3);
 }

--- a/src/adiv5_swdp.c
+++ b/src/adiv5_swdp.c
@@ -23,6 +23,7 @@
  */
 
 #include "general.h"
+#include "exception.h"
 #include "adiv5.h"
 #include "swdptap.h"
 #include "jtagtap.h"
@@ -143,14 +144,12 @@ static uint32_t adiv5_swdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 		return 0;
 	}
 
-	if(ack != SWDP_ACK_OK) {
-		/* Fatal error if invalid ACK response */
-		PLATFORM_FATAL_ERROR(1);
-	}
+	if(ack != SWDP_ACK_OK)
+		raise_exception(EXCEPTION_ERROR, "SWDP invalid ACK");
 
 	if(RnW) {
 		if(swdptap_seq_in_parity(&response, 32))  /* Give up on parity error */
-			PLATFORM_FATAL_ERROR(1);
+			raise_exception(EXCEPTION_ERROR, "SWDP Parity error");
 	} else {
 		swdptap_seq_out_parity(value, 32);
 	}

--- a/src/adiv5_swdp.c
+++ b/src/adiv5_swdp.c
@@ -136,8 +136,8 @@ static uint32_t adiv5_swdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 		ack = swdptap_seq_in(3);
 	} while(--tries && ack == SWDP_ACK_WAIT);
 
-	if (dp->allow_timeout && (ack == SWDP_ACK_WAIT))
-		return 0;
+	if (ack == SWDP_ACK_WAIT)
+		raise_exception(EXCEPTION_TIMEOUT, "SWDP ACK timeout");
 
 	if(ack == SWDP_ACK_FAULT) {
 		dp->fault = 1;

--- a/src/adiv5_swdp.c
+++ b/src/adiv5_swdp.c
@@ -130,11 +130,11 @@ static uint32_t adiv5_swdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 	if((addr == 4) || (addr == 8))
 		request ^= 0x20;
 
-	size_t tries = 1000;
+	platform_timeout_set(2000);
 	do {
 		swdptap_seq_out(request, 8);
 		ack = swdptap_seq_in(3);
-	} while(--tries && ack == SWDP_ACK_WAIT);
+	} while (!platform_timeout_is_expired() && ack == SWDP_ACK_WAIT);
 
 	if (ack == SWDP_ACK_WAIT)
 		raise_exception(EXCEPTION_TIMEOUT, "SWDP ACK timeout");

--- a/src/command.c
+++ b/src/command.c
@@ -23,6 +23,7 @@
  */
 
 #include "general.h"
+#include "exception.h"
 #include "command.h"
 #include "gdb_packet.h"
 #include "jtag_scan.h"
@@ -138,19 +139,30 @@ bool cmd_help(target *t)
 static bool cmd_jtag_scan(target *t, int argc, char **argv)
 {
 	(void)t;
-	uint8_t *irlens = NULL;
+	uint8_t irlens[argc];
 
 	gdb_outf("Target voltage: %s\n", platform_target_voltage());
 
 	if (argc > 1) {
 		/* Accept a list of IR lengths on command line */
-		irlens = alloca(argc);
 		for (int i = 1; i < argc; i++)
 			irlens[i-1] = atoi(argv[i]);
 		irlens[argc-1] = 0;
 	}
 
-	int devs = jtag_scan(irlens);
+	int devs = -1;
+	volatile struct exception e;
+	TRY_CATCH (e, EXCEPTION_ALL) {
+		devs = jtag_scan(argc > 1 ? irlens : NULL);
+	}
+	switch (e.type) {
+	case EXCEPTION_TIMEOUT:
+		gdb_outf("Timeout during scan. Is target stuck in WFI?\n");
+		break;
+	case EXCEPTION_ERROR:
+		gdb_outf("Exception: %s\n", e.msg);
+		break;
+	}
 
 	if(devs < 0) {
 		gdb_out("JTAG device scan failed!\n");
@@ -174,12 +186,24 @@ bool cmd_swdp_scan(void)
 {
 	gdb_outf("Target voltage: %s\n", platform_target_voltage());
 
-	if(adiv5_swdp_scan() < 0) {
+	int devs = -1;
+	volatile struct exception e;
+	TRY_CATCH (e, EXCEPTION_ALL) {
+		devs = adiv5_swdp_scan();
+	}
+	switch (e.type) {
+	case EXCEPTION_TIMEOUT:
+		gdb_outf("Timeout during scan. Is target stuck in WFI?\n");
+		break;
+	case EXCEPTION_ERROR:
+		gdb_outf("Exception: %s\n", e.msg);
+		break;
+	}
+
+	if(devs < 0) {
 		gdb_out("SW-DP scan failed!\n");
 		return false;
 	}
-
-	//gdb_outf("SW-DP detected IDCODE: 0x%08X\n", adiv5_dp_list->idcode);
 
 	cmd_targets(NULL);
 	return true;

--- a/src/exception.c
+++ b/src/exception.c
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2015  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "general.h"
+#include "exception.h"
+
+struct exception *innermost_exception;
+
+void raise_exception(uint32_t type, const char *msg)
+{
+	struct exception *e;
+	for (e = innermost_exception; e; e = e->outer) {
+		if (e->mask & type) {
+			e->type = type;
+			e->msg = msg;
+			innermost_exception = e->outer;
+			longjmp(e->jmpbuf, type);
+		}
+	}
+	PLATFORM_FATAL_ERROR(type);
+}
+

--- a/src/exception.c
+++ b/src/exception.c
@@ -34,6 +34,6 @@ void raise_exception(uint32_t type, const char *msg)
 			longjmp(e->jmpbuf, type);
 		}
 	}
-	PLATFORM_FATAL_ERROR(type);
+	abort();
 }
 

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -158,6 +158,12 @@ gdb_main(void)
 			if (sig < 0)
 				break;
 
+			/* Target disappeared */
+			if (cur_target == NULL) {
+				gdb_putpacket_f("X%02X", sig);
+				break;
+			}
+
 			/* Report reason for halt */
 			if(target_check_hw_wp(cur_target, &watch_addr)) {
 				/* Watchpoint hit */

--- a/src/include/adiv5.h
+++ b/src/include/adiv5.h
@@ -107,12 +107,8 @@ typedef struct ADIv5_DP_s {
 
 	uint32_t idcode;
 
-	bool allow_timeout;
-
 	uint32_t (*dp_read)(struct ADIv5_DP_s *dp, uint16_t addr);
-
 	uint32_t (*error)(struct ADIv5_DP_s *dp);
-
 	uint32_t (*low_access)(struct ADIv5_DP_s *dp, uint8_t RnW,
                                uint16_t addr, uint32_t value);
 

--- a/src/include/exception.h
+++ b/src/include/exception.h
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2015  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Exception handling to escape deep nesting.
+ * Used for the case of communicaiton failure and timeouts.
+ */
+
+/* Example usage:
+ *
+ * volatile struct exception e;
+ * TRY_CATCH (e, EXCEPTION_TIMEOUT) {
+ *    ...
+ *    raise_exception(EXCEPTION_TIMEOUT, "Timeout occurred");
+ *    ...
+ * }
+ * if (e.type == EXCEPTION_TIMEOUT) {
+ *    printf("timeout: %s\n", e.msg);
+ * }
+ */
+
+/* Limitations:
+ * Can't use break, return, goto, etc from inside the TRY_CATCH block.
+ */
+
+#ifndef __EXCEPTION_H
+#define __EXCEPTION_H
+
+#include <setjmp.h>
+#include <stdint.h>
+
+#define EXCEPTION_ERROR   0x01
+#define EXCEPTION_TIMEOUT 0x02
+#define EXCEPTION_ALL     -1
+
+struct exception {
+	uint32_t type;
+	const char *msg;
+	/* private */
+	uint32_t mask;
+	jmp_buf jmpbuf;
+	struct exception *outer;
+};
+
+extern struct exception *innermost_exception;
+
+#define TRY_CATCH(e, type_mask) \
+	(e).type = 0; \
+	(e).mask = (type_mask); \
+	(e).outer = innermost_exception; \
+	innermost_exception = (void*)&(e); \
+	if (setjmp(innermost_exception->jmpbuf) == 0) \
+		for (;innermost_exception == &(e); innermost_exception = (e).outer)
+
+void raise_exception(uint32_t type, const char *msg);
+
+#endif
+

--- a/src/platforms/f4discovery/platform.h
+++ b/src/platforms/f4discovery/platform.h
@@ -24,11 +24,8 @@
 #ifndef __PLATFORM_H
 #define __PLATFORM_H
 
-#include "gdb_packet.h"
 #include "gpio.h"
-#include "morse.h"
 #include "timing.h"
-#include "target.h"
 
 #include <setjmp.h>
 
@@ -142,8 +139,6 @@
 
 #define DEBUG(...)
 
-extern jmp_buf fatal_error_jmpbuf;
-
 #define gpio_set_val(port, pin, val) do {	\
 	if(val)					\
 		gpio_set((port), (pin));	\
@@ -154,16 +149,6 @@ extern jmp_buf fatal_error_jmpbuf;
 #define SET_RUN_STATE(state)	{running_status = (state);}
 #define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, LED_IDLE_RUN, state);}
 #define SET_ERROR_STATE(state)	{gpio_set_val(LED_PORT, LED_ERROR, state);}
-
-#define PLATFORM_SET_FATAL_ERROR_RECOVERY()	{setjmp(fatal_error_jmpbuf);}
-#define PLATFORM_FATAL_ERROR(error)	{ 		\
-	if(running_status) gdb_putpacketz("X1D");	\
-		else gdb_putpacketz("EFF");		\
-	running_status = 0;				\
-	target_list_free();				\
-	morse("TARGET LOST.", 1);			\
-	longjmp(fatal_error_jmpbuf, (error));		\
-}
 
 static inline int platform_hwversion(void)
 {

--- a/src/platforms/f4discovery/platform.h
+++ b/src/platforms/f4discovery/platform.h
@@ -28,6 +28,7 @@
 #include "gpio.h"
 #include "morse.h"
 #include "timing.h"
+#include "target.h"
 
 #include <setjmp.h>
 

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -33,7 +33,6 @@
 
 extern void trace_tick(void);
 
-jmp_buf fatal_error_jmpbuf;
 uint8_t running_status;
 volatile uint32_t timeout_counter;
 

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -86,10 +86,20 @@ platform_init(void)
 	cdcacm_init();
 }
 
+void platform_timeout_set(uint32_t ms)
+{
+	timeout_counter = ms / 10;
+}
+
+bool platform_timeout_is_expired(void)
+{
+	return timeout_counter == 0;
+}
+
 void platform_delay(uint32_t delay)
 {
-	timeout_counter = delay * 10;
-	while(timeout_counter);
+	platform_timeout_set(delay);
+	while (platform_timeout_is_expired());
 }
 
 const char *platform_target_voltage(void)

--- a/src/platforms/launchpad-icdi/platform.h
+++ b/src/platforms/launchpad-icdi/platform.h
@@ -18,6 +18,8 @@
 #define __PLATFORM_H
 
 #include "gdb_packet.h"
+#include "target.h"
+#include "morse.h"
 
 #include <setjmp.h>
 

--- a/src/platforms/launchpad-icdi/platform.h
+++ b/src/platforms/launchpad-icdi/platform.h
@@ -17,12 +17,6 @@
 #ifndef __PLATFORM_H
 #define __PLATFORM_H
 
-#include "gdb_packet.h"
-#include "target.h"
-#include "morse.h"
-
-#include <setjmp.h>
-
 #include <libopencm3/lm4f/gpio.h>
 #include <libopencm3/usb/usbd.h>
 
@@ -31,7 +25,6 @@
 #define DFU_IDENT               "Black Magic Firmware Upgrade (Launchpad)"
 #define DFU_IFACE_STRING	"lolwut"
 
-extern jmp_buf fatal_error_jmpbuf;
 extern uint8_t running_status;
 extern volatile uint32_t timeout_counter;
 
@@ -107,16 +100,6 @@ extern usbd_driver lm4f_usb_driver;
 #define SET_RUN_STATE(state)	{running_status = (state);}
 #define SET_IDLE_STATE(state)	{}
 #define SET_ERROR_STATE(state)	SET_IDLE_STATE(state)
-
-#define PLATFORM_SET_FATAL_ERROR_RECOVERY()	{setjmp(fatal_error_jmpbuf);}
-#define PLATFORM_FATAL_ERROR(error) {			\
-	if( running_status ) gdb_putpacketz("X1D");	\
-		else gdb_putpacketz("EFF");		\
-	running_status = 0;				\
-	target_list_free();				\
-	morse("TARGET LOST.", 1);			\
-	longjmp(fatal_error_jmpbuf, (error));		\
-}
 
 #define PLATFORM_HAS_TRACESWO
 

--- a/src/platforms/libftdi/platform.c
+++ b/src/platforms/libftdi/platform.c
@@ -21,6 +21,7 @@
 #include "gdb_if.h"
 
 #include <assert.h>
+#include <sys/time.h>
 
 struct ftdi_context *ftdic;
 
@@ -256,5 +257,23 @@ const char *platform_target_voltage(void)
 void platform_delay(uint32_t delay)
 {
 	usleep(delay * 100000);
+}
+
+static uint32_t timeout_time;
+static uint32_t time_ms(void)
+{
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+}
+
+void platform_timeout_set(uint32_t ms)
+{
+	timeout_time = time_ms() + ms;
+}
+
+bool platform_timeout_is_expired(void)
+{
+	return time_ms() > timeout_time;
 }
 

--- a/src/platforms/libftdi/platform.h
+++ b/src/platforms/libftdi/platform.h
@@ -36,9 +36,6 @@
 #define SET_IDLE_STATE(state)
 #define SET_ERROR_STATE(state)
 
-#define PLATFORM_FATAL_ERROR(error)	abort()
-#define PLATFORM_SET_FATAL_ERROR_RECOVERY()
-
 extern struct ftdi_context *ftdic;
 
 void platform_buffer_flush(void);

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -35,8 +35,6 @@
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/stm32/f1/adc.h>
 
-jmp_buf fatal_error_jmpbuf;
-
 static void adc_init(void);
 static void setup_vbus_irq(void);
 

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -24,12 +24,8 @@
 #ifndef __PLATFORM_H
 #define __PLATFORM_H
 
-#include "gdb_packet.h"
 #include "gpio.h"
-#include "morse.h"
 #include "timing.h"
-
-#include <setjmp.h>
 
 #define PLATFORM_HAS_TRACESWO
 #define PLATFORM_HAS_POWER_SWITCH
@@ -147,22 +143,9 @@
 
 #define DEBUG(...)
 
-extern jmp_buf fatal_error_jmpbuf;
-
 #define SET_RUN_STATE(state)	{running_status = (state);}
 #define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, LED_IDLE_RUN, state);}
 #define SET_ERROR_STATE(state)	{gpio_set_val(LED_PORT, LED_ERROR, state);}
-
-#include "target.h"
-#define PLATFORM_SET_FATAL_ERROR_RECOVERY()	{setjmp(fatal_error_jmpbuf);}
-#define PLATFORM_FATAL_ERROR(error)	do { 		\
-	if(running_status) gdb_putpacketz("X1D");	\
-		else gdb_putpacketz("EFF");		\
-	running_status = 0;				\
-	target_list_free();				\
-	morse("TARGET LOST.", 1);			\
-	longjmp(fatal_error_jmpbuf, (error));		\
-} while (0)
 
 /* Use newlib provided integer only stdio functions */
 #define sscanf siscanf

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -153,6 +153,7 @@ extern jmp_buf fatal_error_jmpbuf;
 #define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, LED_IDLE_RUN, state);}
 #define SET_ERROR_STATE(state)	{gpio_set_val(LED_PORT, LED_ERROR, state);}
 
+#include "target.h"
 #define PLATFORM_SET_FATAL_ERROR_RECOVERY()	{setjmp(fatal_error_jmpbuf);}
 #define PLATFORM_FATAL_ERROR(error)	do { 		\
 	if(running_status) gdb_putpacketz("X1D");	\

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -36,8 +36,6 @@
 uint8_t running_status;
 volatile uint32_t timeout_counter;
 
-jmp_buf fatal_error_jmpbuf;
-
 uint16_t led_idle_run;
 /* Pins PC[14:13] are used to detect hardware revision. Read
  * 11 for STLink V1 e.g. on VL Discovery, tag as hwversion 0

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -27,6 +27,7 @@
 #include "gdb_packet.h"
 #include "gpio.h"
 #include "timing.h"
+#include "target.h"
 
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/stm32/f1/memorymap.h>

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -24,16 +24,12 @@
 #ifndef __PLATFORM_H
 #define __PLATFORM_H
 
-#include "gdb_packet.h"
 #include "gpio.h"
 #include "timing.h"
-#include "target.h"
 
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/stm32/f1/memorymap.h>
 #include <libopencm3/usb/usbd.h>
-
-#include <setjmp.h>
 
 #define BOARD_IDENT       "Black Magic Probe (STLINK), (Firmware 1.5" VERSION_SUFFIX ", build " BUILDDATE ")"
 #define BOARD_IDENT_DFU   "Black Magic (Upgrade) for STLink/Discovery, (Firmware 1.5" VERSION_SUFFIX ", build " BUILDDATE ")"
@@ -131,22 +127,11 @@
 
 #define DEBUG(...)
 
-extern jmp_buf fatal_error_jmpbuf;
-
 extern uint16_t led_idle_run;
 #define LED_IDLE_RUN            led_idle_run
 #define SET_RUN_STATE(state)	{running_status = (state);}
 #define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, led_idle_run, state);}
 #define SET_ERROR_STATE(x)
-
-#define PLATFORM_SET_FATAL_ERROR_RECOVERY()	{setjmp(fatal_error_jmpbuf);}
-#define PLATFORM_FATAL_ERROR(error)	do { 		\
-	if(running_status) gdb_putpacketz("X1D");	\
-		else gdb_putpacketz("EFF");		\
-	running_status = 0;				\
-	target_list_free();				\
-	longjmp(fatal_error_jmpbuf, (error));		\
-} while (0)
 
 /* Use newlib provided integer only stdio functions */
 #define sscanf siscanf

--- a/src/platforms/stm32/timing.c
+++ b/src/platforms/stm32/timing.c
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "general.h"
+#include "morse.h"
 
 #include <libopencm3/cm3/systick.h>
 #include <libopencm3/cm3/scb.h>

--- a/src/platforms/swlink/Makefile.inc
+++ b/src/platforms/swlink/Makefile.inc
@@ -2,6 +2,7 @@ CROSS_COMPILE ?= arm-none-eabi-
 CC = $(CROSS_COMPILE)gcc
 OBJCOPY = $(CROSS_COMPILE)objcopy
 
+OPT_FLAGS = -Os
 CFLAGS += -mcpu=cortex-m3 -mthumb \
 	-DSTM32F1 -DDISCOVERY_SWLINK -I../libopencm3/include \
 	-I platforms/stm32

--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -33,8 +33,6 @@
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/stm32/f1/adc.h>
 
-jmp_buf fatal_error_jmpbuf;
-
 void platform_init(void)
 {
 	uint32_t data;

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -27,6 +27,7 @@
 #include "gdb_packet.h"
 #include "gpio.h"
 #include "timing.h"
+#include "target.h"
 
 #include <setjmp.h>
 

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -24,12 +24,8 @@
 #ifndef __PLATFORM_H
 #define __PLATFORM_H
 
-#include "gdb_packet.h"
 #include "gpio.h"
 #include "timing.h"
-#include "target.h"
-
-#include <setjmp.h>
 
 #define BOARD_IDENT            "Black Magic Probe (SWLINK), (Firmware 1.5" VERSION_SUFFIX ", build " BUILDDATE ")"
 #define BOARD_IDENT_DFU	       "Black Magic (Upgrade), STM8S Discovery, (Firmware 1.5" VERSION_SUFFIX ", build " BUILDDATE ")"
@@ -126,20 +122,9 @@
 
 #define DEBUG(...)
 
-extern jmp_buf fatal_error_jmpbuf;
-
 #define SET_RUN_STATE(state)	{running_status = (state);}
 #define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, LED_IDLE_RUN, state);}
 #define SET_ERROR_STATE(x)
-
-#define PLATFORM_SET_FATAL_ERROR_RECOVERY()	{setjmp(fatal_error_jmpbuf);}
-#define PLATFORM_FATAL_ERROR(error)	{ 		\
-	if(running_status) gdb_putpacketz("X1D");	\
-		else gdb_putpacketz("EFF");		\
-	running_status = 0;				\
-	target_list_free();				\
-	longjmp(fatal_error_jmpbuf, (error));		\
-}
 
 /* Use newlib provided integer only stdio functions */
 #define sscanf siscanf


### PR DESCRIPTION
Implement a programmatic way of raising and handling exceptions to replace the platform specific macros based on setjmp/longjmp.

This also allows timeouts to be handled more gracefully, and better user feedback when the target is in WFI.