### PR TITLE
[Bugfix] stm32f1_probe would always return true, breaking support for…

### DIFF
--- a/src/stm32f1.c
+++ b/src/stm32f1.c
@@ -162,7 +162,12 @@ bool stm32f1_probe(target *t)
 		block_size = 0x800;
 		break;
 	}
-	if (t->driver) {
+	switch(t->idcode) {
+	case 0x444:  /* STM32F03 RM0091 Rev.7 */
+	case 0x445:  /* STM32F04 RM0091 Rev.7 */
+	case 0x440:  /* STM32F05 RM0091 Rev.7 */
+	case 0x448:  /* STM32F07 RM0091 Rev.7 */
+	case 0x442:  /* STM32F09 RM0091 Rev.7 */
 		flash_size = (target_mem_read32(t, FLASHSIZE_F0) & 0xffff) *0x400;
 		gdb_outf("flash size %d block_size %d\n", flash_size, block_size);
 		target_add_ram(t, 0x20000000, 0x5000);
@@ -353,4 +358,3 @@ static bool stm32f1_cmd_option(target *t, int argc, char *argv[])
 	}
 	return true;
 }
-

--- a/src/stm32f1.c
+++ b/src/stm32f1.c
@@ -161,22 +161,16 @@ bool stm32f1_probe(target *t)
 		t->driver = "STM32F09";
 		block_size = 0x800;
 		break;
-	}
-	switch(t->idcode) {
-	case 0x444:  /* STM32F03 RM0091 Rev.7 */
-	case 0x445:  /* STM32F04 RM0091 Rev.7 */
-	case 0x440:  /* STM32F05 RM0091 Rev.7 */
-	case 0x448:  /* STM32F07 RM0091 Rev.7 */
-	case 0x442:  /* STM32F09 RM0091 Rev.7 */
-		flash_size = (target_mem_read32(t, FLASHSIZE_F0) & 0xffff) *0x400;
-		gdb_outf("flash size %d block_size %d\n", flash_size, block_size);
-		target_add_ram(t, 0x20000000, 0x5000);
-		stm32f1_add_flash(t, 0x8000000, flash_size, block_size);
-		target_add_commands(t, stm32f1_cmd_list, "STM32F0");
-		return true;
+	default:     /* NONE */
+		return false;
 	}
 
-	return false;
+	flash_size = (target_mem_read32(t, FLASHSIZE_F0) & 0xffff) *0x400;
+	gdb_outf("flash size %d block_size %d\n", flash_size, block_size);
+	target_add_ram(t, 0x20000000, 0x5000);
+	stm32f1_add_flash(t, 0x8000000, flash_size, block_size);
+	target_add_commands(t, stm32f1_cmd_list, "STM32F0");
+	return true;
 }
 
 static void stm32f1_flash_unlock(target *t)


### PR DESCRIPTION
… all other targets

The intention of `if (t->driver)` conditional was to test if any of the cases in the preceeding switch/case were met. However t->driver was previously set to point to a default value in cortexm.c:200 and therefore this would always evaluate to true. I've replaced the broken if statement with a duplicate of the switch/case run above.

It looks like this was introduced in 09544bc7101981f2688e0a678138dc4580ea3f76 (PR #92) but 492d6c9cf8f735eea5478c99aee43608549218d7 maybe contributes to the confusion in this instance.