### PR TITLE
Add 0x0072 as a valid & supported idcode for NRF51

### DIFF
--- a/src/nrf51.c
+++ b/src/nrf51.c
@@ -119,6 +119,7 @@ bool nrf51_probe(target *t)
 	case 0x004D:
 	case 0x0026:
 	case 0x004C:
+	case 0x0072:
 		t->driver = "Nordic nRF51";
 		target_add_ram(t, 0x20000000, 0x4000);
 		nrf51_add_flash(t, 0x00000000, 0x40000, NRF51_PAGE_SIZE);


### PR DESCRIPTION
Hi,

The NRF51 chip I'm using has the idcode 0x0072. I've tested the Blackmagic debugger with the chip on my board and everything is working fine.

Thanks