### PR TITLE
TI TM4C/LM4F cdc-acm fixes

### DIFF
--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -498,7 +498,7 @@ static void cdcacm_set_config(usbd_device *dev, uint16_t wValue)
 	configured = wValue;
 
 	/* GDB interface */
-#ifdef STM32F4
+#if defined(STM32F4) || defined(LM4F)
 	usbd_ep_setup(dev, 0x01, USB_ENDPOINT_ATTR_BULK,
 	              CDCACM_PACKET_SIZE, gdb_usb_out_cb);
 #else

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -46,8 +46,8 @@ void sys_tick_handler(void)
 void
 platform_init(void)
 {
-        int i;
-        for(i=0; i<1000000; i++);
+	int i;
+	for(i=0; i<1000000; i++);
 
 	rcc_sysclk_config(OSCSRC_MOSC, XTAL_16M, PLL_DIV_80MHZ);
 
@@ -77,12 +77,12 @@ platform_init(void)
 	periph_clock_enable(RCC_GPIOD);
 	__asm__("nop"); __asm__("nop"); __asm__("nop");
 	gpio_mode_setup(GPIOD_BASE, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO4|GPIO5);
+	usbuart_init();
+	cdcacm_init();
+
 	usb_enable_interrupts(USB_INT_RESET | USB_INT_DISCON |
 	                      USB_INT_RESUME | USB_INT_SUSPEND,
 	                      0xff, 0xff);
-
-	usbuart_init();
-	cdcacm_init();
 }
 
 void platform_timeout_set(uint32_t ms)

--- a/src/platforms/launchpad-icdi/platform.h
+++ b/src/platforms/launchpad-icdi/platform.h
@@ -96,6 +96,7 @@ extern usbd_driver lm4f_usb_driver;
 #define sscanf siscanf
 #define sprintf siprintf
 #define vasprintf vasiprintf
+#define snprintf sniprintf
 
 #define DEBUG(...)
 


### PR DESCRIPTION
Hi,

These changes fix USB enumeration and communication over the CDC serial port on the TI Launchpad platform. With them applied, connecting to the probe and scan using both JTAG and SWD works. I'm using a LM4F120 Launchpad but the TM4C123 shouldn't be any different in this regard.

Attaching to the target fails, however. I've traced it down to the snprintf call in map_ram() in target.c. In fact, any call to snprintf with a format argument seems to crash the MCU. Google suggests it might be a stack size issue, but I'm not sure how to rectify that.