### PR TITLE
Some various fixes

### DIFF
--- a/flashstub/Makefile
+++ b/flashstub/Makefile
@@ -11,7 +11,7 @@ endif
 CFLAGS=-Os -std=gnu99 -mcpu=cortex-m0 -mthumb -I../libopencm3/include
 ASFLAGS=-mcpu=cortex-m3 -mthumb
 
-all:	lmi.stub stm32f4.stub stm32l4.stub nrf51.stub stm32f1.stub
+all:	lmi.stub stm32f4.stub stm32l4.stub nrf51.stub stm32f1.stub efm32.stub
 
 stm32f1.o: CFLAGS += -DSTM32F1
 stm32f4.o: CFLAGS += -DSTM32F4

--- a/flashstub/Makefile
+++ b/flashstub/Makefile
@@ -13,15 +13,10 @@ ASFLAGS=-mcpu=cortex-m3 -mthumb
 
 all:	lmi.stub stm32f4.stub stm32l4.stub nrf51.stub stm32f1.stub
 
-stm32f1.o: stm32f1.c
-	$(Q)echo "  CC      $<"
-	$(Q)$(CC) $(CFLAGS) -DSTM32F1 -o $@ -c $<
+stm32f1.o: CFLAGS += -DSTM32F1
+stm32f4.o: CFLAGS += -DSTM32F4
 
-stm32f4.o: stm32f4.c
-	$(Q)echo "  CC      $<"
-	$(Q)$(CC) $(CFLAGS) -DSTM32F4 -o $@ -c $<
-
-stm32l4.o: stm32l4.c
+%.o:    %.c
 	$(Q)echo "  CC      $<"
 	$(Q)$(CC) $(CFLAGS) -o $@ -c $<
 

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -97,13 +97,19 @@ uint32_t crc32_calc(uint32_t crc, uint8_t data)
 uint32_t generic_crc32(target *t, uint32_t base, int len)
 {
 	uint32_t crc = -1;
-	uint8_t byte;
+	static uint8_t bytes[128];
 
-	while (len--) {
-		byte = target_mem_read8(t, base);
+	while (len) {
+		uint32_t i;
+		uint32_t read_len = len >= 128 ? 128 : len;
 
-		crc = crc32_calc(crc, byte);
-		base++;
+		target_mem_read(t, bytes, base, read_len);
+
+		for (i=0; i<read_len; i++)
+			crc = crc32_calc(crc, bytes[i]);
+
+		base += read_len;
+		len -= read_len;
 	}
 	return crc;
 }

--- a/src/efm32.c
+++ b/src/efm32.c
@@ -334,6 +334,7 @@ bool efm32_probe(target *t)
 	uint32_t ram_size   = efm32_read_ram_size(t)   * 0x400;
 
 	/* Setup Target */
+	t->target_options |= CORTEXM_TOPT_INHIBIT_SRST;
 	t->driver = variant_string;
 	gdb_outf("flash size %d page size %d\n", flash_size, flash_page_size);
 	target_add_ram (t, SRAM_BASE, ram_size);

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -41,7 +41,7 @@
 #define ERROR_IF_NO_TARGET()	\
 	if(!cur_target) { gdb_putpacketz("EFF"); break; }
 
-static char pbuf[BUF_SIZE];
+static char pbuf[BUF_SIZE+1];
 
 static target *cur_target;
 static target *last_target;


### PR DESCRIPTION
These fixes several issues that we found during tests with our hardware:

* crc32: speed up the generic crc32 routine which caused us some trouble by buffering larger chunks of memory. I don't know if the STM32's routine needs similar modification.
* flashstub: mostly cosmetic adjustments in Makefile
* efm32: we had some trouble when doing loads and breaks with srst switching enabled
* gdb_main.c: fixes a buffer overflow, observed when issuing `dump` commands

In my sense, the last one is the most critical.

Please let me know if you'd prefer these to be submitted in their own pull request.