### PR TITLE
Update nRF51 IDs, add nRF51422 and xxAB/xxAC devices.

### DIFF
--- a/scripts/get_openocd_nrf51_ids.py
+++ b/scripts/get_openocd_nrf51_ids.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+"""Pulls nRF51 IDs from openocd's nrf51.c in a form suitable for
+pasting into blackmagic's nrf51.c
+
+"""
+
+import subprocess,re
+
+cmd = 'git archive --remote=git://git.code.sf.net/p/openocd/code HEAD src/flash/nor/nrf51.c | tar -xO'
+
+class Spec():
+    def __repr__(self):
+        return "0x%04X: /* %s %s %s */"%(self.hwid,self.comment, self.variant,self.build_code)
+
+fd = subprocess.Popen(cmd,shell=True,stdout=subprocess.PIPE).stdout
+
+specdict={}
+specs=[]
+spec=Spec()
+for line in fd.read().split('\n'):
+    m=re.search('/\*(.*)\*/',line)
+    if m:
+        lastcomment=m.group(1)
+
+    m=re.search('.hwid.*=\s*(0x[0-9A-F]*),',line)
+    if m:
+        spec.hwid=int(m.group(1),base=0)
+    m=re.search('.variant.*=\s*"(.*)",',line)
+    if m:
+        spec.variant=m.group(1)
+    m=re.search('.build_code.*=\s*"(.*)",',line)
+    if m:
+        spec.build_code=m.group(1)
+    m=re.search('.flash_size_kb.*=\s*([0-9]*),',line)
+    if m:
+        spec.flash_size_kb=int(m.group(1),base=0)
+        ram,flash = {'AA':(16,256),
+                     'AB':(16,128),
+                     'AC':(32,256)}[spec.variant[-2:]]
+        assert flash==spec.flash_size_kb
+        spec.ram_size_kb = ram
+        nicecomment =lastcomment.strip().replace('IC ','').replace('Devices ','').replace('.','')
+        spec.comment=nicecomment
+
+        specdict.setdefault((ram,flash),[]).append(spec)
+        specs.append(spec)
+        spec=Spec()
+
+for (ram,flash),specs in specdict.iteritems():
+    specs.sort(key=lambda x:x.hwid)
+    for spec in specs:
+        print "\tcase",spec
+    print '\t\tt->driver = "Nordic nRF51";'
+    print '\t\ttarget_add_ram(t, 0x20000000, 0x%X);'%(1024*ram)
+    print '\t\tnrf51_add_flash(t, 0x00000000, 0x%X, NRF51_PAGE_SIZE);'%(1024*flash)
+    print '\t\tnrf51_add_flash(t, NRF51_UICR, 0x100, 0x100);'
+    print '\t\ttarget_add_commands(t, nrf51_cmd_list, "nRF51");'
+    print '\t\treturn true;'
+

--- a/src/nrf51.c
+++ b/src/nrf51.c
@@ -108,20 +108,54 @@ bool nrf51_probe(target *t)
 	t->idcode = target_mem_read32(t, NRF51_FICR_CONFIGID) & 0xFFFF;
 
 	switch (t->idcode) {
-	case 0x001D:
-	case 0x002A:
-	case 0x0044:
-	case 0x003C:
-	case 0x0020:
-	case 0x002F:
-	case 0x0040:
-	case 0x0047:
-	case 0x004D:
-	case 0x0026:
-	case 0x004C:
-	case 0x0072:
+	case 0x001D: /* nRF51822 (rev 1) QFAA CA/C0 */
+	case 0x001E: /* nRF51422 (rev 1) QFAA CA */
+	case 0x0020: /* nRF51822 (rev 1) CEAA BA */
+	case 0x0024: /* nRF51422 (rev 1) QFAA C0 */
+	case 0x002A: /* nRF51822 (rev 2) QFAA FA0 */
+	case 0x002D: /* nRF51422 (rev 2) QFAA DAA */
+	case 0x002E: /* nRF51422 (rev 2) QFAA E0 */
+	case 0x002F: /* nRF51822 (rev 1) CEAA B0 */
+	case 0x0031: /* nRF51422 (rev 1) CEAA A0A */
+	case 0x003C: /* nRF51822 (rev 2) QFAA G0 */
+	case 0x0040: /* nRF51822 (rev 2) CEAA CA0 */
+	case 0x0044: /* nRF51822 (rev 2) QFAA GC0 */
+	case 0x0047: /* nRF51822 (rev 2) CEAA DA0 */
+	case 0x004D: /* nRF51822 (rev 2) CEAA D00 */
+	case 0x0050: /* nRF51422 (rev 2) CEAA B0 */
+	case 0x0072: /* nRF51822 (rev 3) QFAA H0 */
+	case 0x0073: /* nRF51422 (rev 3) QFAA F0 */
+	case 0x0079: /* nRF51822 (rev 3) CEAA E0 */
+	case 0x007A: /* nRF51422 (rev 3) CEAA C0 */
 		t->driver = "Nordic nRF51";
 		target_add_ram(t, 0x20000000, 0x4000);
+		nrf51_add_flash(t, 0x00000000, 0x40000, NRF51_PAGE_SIZE);
+		nrf51_add_flash(t, NRF51_UICR, 0x100, 0x100);
+		target_add_commands(t, nrf51_cmd_list, "nRF51");
+		return true;
+	case 0x0026: /* nRF51822 (rev 1) QFAB AA */
+	case 0x0027: /* nRF51822 (rev 1) QFAB A0 */
+	case 0x004C: /* nRF51822 (rev 2) QFAB B0 */
+	case 0x0061: /* nRF51422 (rev 2) QFAB A00 */
+	case 0x007B: /* nRF51822 (rev 3) QFAB C0 */
+	case 0x007C: /* nRF51422 (rev 3) QFAB B0 */
+	case 0x007D: /* nRF51822 (rev 3) CDAB A0 */
+	case 0x007E: /* nRF51422 (rev 3) CDAB A0 */
+		t->driver = "Nordic nRF51";
+		target_add_ram(t, 0x20000000, 0x4000);
+		nrf51_add_flash(t, 0x00000000, 0x20000, NRF51_PAGE_SIZE);
+		nrf51_add_flash(t, NRF51_UICR, 0x100, 0x100);
+		target_add_commands(t, nrf51_cmd_list, "nRF51");
+		return true;
+	case 0x0071: /* nRF51422 (rev 3) QFAC AB */
+	case 0x0083: /* nRF51822 (rev 3) QFAC A0 */
+	case 0x0084: /* nRF51422 (rev 3) QFAC A1 */
+	case 0x0085: /* nRF51422 (rev 3) QFAC A0 */
+	case 0x0086: /* nRF51422 (rev 3) QFAC A1 */
+	case 0x0087: /* nRF51822 (rev 3) CFAC A0 */
+	case 0x0088: /* nRF51422 (rev 3) CFAC A0 */
+		t->driver = "Nordic nRF51";
+		target_add_ram(t, 0x20000000, 0x8000);
 		nrf51_add_flash(t, 0x00000000, 0x40000, NRF51_PAGE_SIZE);
 		nrf51_add_flash(t, NRF51_UICR, 0x100, 0x100);
 		target_add_commands(t, nrf51_cmd_list, "nRF51");


### PR DESCRIPTION
There were a lot of nRF51 device ids missing. I wrote a script to pull nRF51 IDs from the openocd repository, which seems to be more up-to-date.  The script's output goes in nrf51.c.