### PR TITLE
[native] Check for hardware version by pull-up and -down. Print HW Ve…

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -108,7 +108,7 @@ int command_process(target *t, char *cmd)
 
 bool cmd_version(void)
 {
-	gdb_out("Black Magic Probe (Firmware " FIRMWARE_VERSION ")\n");
+	gdb_outf("Black Magic Probe (Firmware " FIRMWARE_VERSION ") (Hardware Version %d)\n", platform_hwversion());
 	gdb_out("Copyright (C) 2015  Black Sphere Technologies Ltd.\n");
 	gdb_out("License GPLv3+: GNU GPL version 3 or later "
 		"<http://gnu.org/licenses/gpl.html>\n\n");

--- a/src/platforms/launchpad-icdi/platform.h
+++ b/src/platforms/launchpad-icdi/platform.h
@@ -116,4 +116,9 @@ inline static uint8_t gpio_get(uint32_t port, uint8_t pin) {
 
 #define disconnect_usb() do { usbd_disconnect(usbdev,1); nvic_disable_irq(USB_IRQ);} while(0)
 
+static inline int platform_hwversion(void)
+{
+	        return 0;
+}
+
 #endif

--- a/src/platforms/libftdi/platform.h
+++ b/src/platforms/libftdi/platform.h
@@ -42,5 +42,10 @@ void platform_buffer_flush(void);
 int platform_buffer_write(const uint8_t *data, int size);
 int platform_buffer_read(uint8_t *data, int size);
 
+static inline int platform_hwversion(void)
+{
+	        return 0;
+}
+
 #endif
 

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -127,6 +127,11 @@
 #define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, LED_IDLE_RUN, state);}
 #define SET_ERROR_STATE(x)
 
+static inline int platform_hwversion(void)
+{
+	        return 0;
+}
+
 /* Use newlib provided integer only stdio functions */
 #define sscanf siscanf
 #define sprintf siprintf


### PR DESCRIPTION
…rsion in mon command.

Until now the native hardware was pulling PB5-7 down and checking if
they were asserted high. BMPMV2b is pulling the pins down instead of
high. The hardware version routine now determines the hardware version
based on the fact if a pin is asserted at all. This means that if a pin
is left floating, the version number bit will be 0, and if the pin is
asserted either high or low the bit will be set to 1. While we were
already at it the "monitor version" command in GDB will now also print
the hardware version number.