### PR TITLE
[native] Make the native bootloader bit more flashy.

### DIFF
--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -90,9 +90,12 @@
 
 #define LED_PORT	GPIOB
 #define LED_PORT_UART	GPIOB
-#define LED_UART	GPIO2
-#define LED_IDLE_RUN	GPIO10
-#define LED_ERROR	GPIO11
+#define LED_0		GPIO2
+#define LED_1		GPIO10
+#define LED_2		GPIO11
+#define LED_UART	LED_2
+#define LED_IDLE_RUN	LED_1
+#define LED_ERROR	LED_0
 
 #define TMS_SET_MODE() \
 	gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_50_MHZ, \

--- a/src/platforms/stlink/dfu_upgrade.c
+++ b/src/platforms/stlink/dfu_upgrade.c
@@ -107,6 +107,10 @@ int main(void)
 	dfu_main();
 }
 
+void dfu_event(void)
+{
+}
+
 void sys_tick_handler(void)
 {
 	if (rev == 0) {

--- a/src/platforms/stlink/usbdfu.c
+++ b/src/platforms/stlink/usbdfu.c
@@ -125,6 +125,10 @@ int main(void)
 	dfu_main();
 }
 
+void dfu_event(void)
+{
+}
+
 void sys_tick_handler(void)
 {
 	if (rev == 0) {

--- a/src/platforms/stm32/dfu_f1.c
+++ b/src/platforms/stm32/dfu_f1.c
@@ -49,6 +49,9 @@ void dfu_flash_program_buffer(uint32_t baseaddr, void *buf, int len)
 	for(int i = 0; i < len; i += 2)
 		flash_program_half_word(baseaddr + i,
 				*(uint16_t*)(buf+i));
+
+	/* Call the platform specific dfu event callback. */
+	dfu_event();
 }
 
 uint32_t dfu_poll_timeout(uint8_t cmd, uint32_t addr, uint16_t blocknum)

--- a/src/platforms/stm32/usbdfu.h
+++ b/src/platforms/stm32/usbdfu.h
@@ -39,6 +39,7 @@ void dfu_flash_program_buffer(uint32_t baseaddr, void *buf, int len);
 uint32_t dfu_poll_timeout(uint8_t cmd, uint32_t addr, uint16_t blocknum);
 void dfu_protect(dfu_mode_t mode);
 void dfu_jump_app_if_valid(void);
+void dfu_event(void);
 
 /* Platform specific function */
 void dfu_detach(void);

--- a/src/platforms/swlink/usbdfu.c
+++ b/src/platforms/swlink/usbdfu.c
@@ -88,6 +88,10 @@ int main(void)
 	dfu_main();
 }
 
+void dfu_event(void)
+{
+}
+
 void sys_tick_handler(void)
 {
 	gpio_toggle(GPIOA, GPIO8);


### PR DESCRIPTION
This change has also a practical reason. When flashing and testing the
hardware this change makes it easier to make sure all the LEDs work. Now
when the DFU bootloader is idle it is scanning the LEDs making it easy
to see if one of them has an issue.

In addition to that, the bootloader now indicates when there is data
being flashed using the DFU interface. In cases when one has more than
one device connected and accidently starts flashing a wrong device this
is very useful feature to have.