### PR TITLE
Cleanup of SRST handling.

### DIFF
--- a/src/adiv5_swdp.c
+++ b/src/adiv5_swdp.c
@@ -50,8 +50,6 @@ int adiv5_swdp_scan(void)
 	ADIv5_DP_t *dp = (void*)calloc(1, sizeof(*dp));
 
 	swdptap_init();
-	if(connect_assert_srst)
-		jtagtap_srst(true); /* will be deasserted after attach */
 	/* Read the SW-DP IDCODE register to syncronise */
 	/* This could be done with adiv_swdp_low_access(), but this doesn't
 	 * allow the ack to be checked here. */

--- a/src/cortexm.c
+++ b/src/cortexm.c
@@ -27,8 +27,6 @@
  */
 #include "general.h"
 #include "exception.h"
-#include "jtagtap.h"
-#include "jtag_scan.h"
 #include "adiv5.h"
 #include "target.h"
 #include "command.h"
@@ -273,7 +271,7 @@ bool cortexm_attach(target *t)
 
 	target_halt_request(t);
 	tries = 10;
-	while(!connect_assert_srst && !target_halt_wait(t) && --tries)
+	while(!platform_srst_get_val() && !target_halt_wait(t) && --tries)
 		platform_delay(2);
 	if(!tries)
 		return false;
@@ -318,8 +316,7 @@ bool cortexm_attach(target *t)
 	t->clear_hw_wp = cortexm_clear_hw_wp;
 	t->check_hw_wp = cortexm_check_hw_wp;
 
-	if(connect_assert_srst)
-		jtagtap_srst(false);
+	platform_srst_set_val(false);
 
 	return true;
 }
@@ -426,8 +423,8 @@ static void cortexm_pc_write(target *t, const uint32_t val)
 static void cortexm_reset(target *t)
 {
 	if ((t->target_options & CORTEXM_TOPT_INHIBIT_SRST) == 0) {
-		jtagtap_srst(true);
-		jtagtap_srst(false);
+		platform_srst_set_val(true);
+		platform_srst_set_val(false);
 	}
 
 	/* Read DHCSR here to clear S_RESET_ST bit before reset */

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -27,8 +27,6 @@ int jtagtap_init(void);
 
 void jtagtap_reset(void);
 
-void jtagtap_srst(bool assert);
-
 uint8_t jtagtap_next(const uint8_t TMS, const uint8_t TDI);
 /* tap_next executes one state transision in the JTAG TAP state machine:
  * - Ensure TCK is low

--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -36,6 +36,7 @@ void platform_timeout_set(uint32_t ms);
 bool platform_timeout_is_expired(void);
 void platform_delay(uint32_t delay);
 void platform_srst_set_val(bool assert);
+bool platform_srst_get_val(void);
 bool platform_target_get_power(void);
 void platform_target_set_power(bool power);
 void platform_request_boot(void);

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -206,7 +206,6 @@ struct target_command_s {
 };
 
 extern target *target_list;
-extern bool connect_assert_srst;
 
 target *target_new(unsigned size);
 void target_list_free(void);

--- a/src/jtag_scan.c
+++ b/src/jtag_scan.c
@@ -105,8 +105,6 @@ int jtag_scan(const uint8_t *irlens)
 	 */
 	DEBUG("Resetting TAP\n");
 	jtagtap_init();
-	if(connect_assert_srst)
-		jtagtap_srst(true); /* will be deasserted after attach */
 	jtagtap_reset();
 
 	if (irlens) {

--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -78,6 +78,9 @@ void platform_init(void)
 	cdcacm_init();
 }
 
+void platform_srst_set_val(bool assert) { (void)assert; }
+bool platform_srst_get_val(void) { return false; }
+
 const char *platform_target_voltage(void)
 {
 	return "ABSENT!";

--- a/src/platforms/hydrabus/platform.c
+++ b/src/platforms/hydrabus/platform.c
@@ -78,6 +78,9 @@ void platform_init(void)
 	cdcacm_init();
 }
 
+void platform_srst_set_val(bool assert) { (void)assert; }
+bool platform_srst_get_val(void) { return false; }
+
 const char *platform_target_voltage(void)
 {
 	return "ABSENT!";

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -85,6 +85,22 @@ platform_init(void)
 	                      0xff, 0xff);
 }
 
+void platform_srst_set_val(bool assert)
+{
+	volatile int i;
+	if (assert) {
+		gpio_clear(SRST_PORT, SRST_PIN);
+		for(i = 0; i < 10000; i++) asm("nop");
+	} else {
+		gpio_set(SRST_PORT, SRST_PIN);
+	}
+}
+
+bool platform_srst_get_val(void)
+{
+	return gpio_get(SRST_PORT, SRST_PIN) == 0;
+}
+
 void platform_timeout_set(uint32_t ms)
 {
 	timeout_counter = ms / 10;

--- a/src/platforms/libftdi/jtagtap.c
+++ b/src/platforms/libftdi/jtagtap.c
@@ -67,15 +67,6 @@ void jtagtap_reset(void)
 	jtagtap_soft_reset();
 }
 
-void jtagtap_srst(bool assert)
-{
-	(void)assert;
-	platform_buffer_flush();
-	//ftdi_write_data(ftdic, "\x80\x88\xAB", 3);
-	//usleep(1000);
-	//ftdi_write_data(ftdic, "\x80\xA8\xAB", 3);
-}
-
 #ifndef PROVIDE_GENERIC_TAP_TMS_SEQ
 void
 jtagtap_tms_seq(uint32_t MS, int ticks)

--- a/src/platforms/libftdi/platform.c
+++ b/src/platforms/libftdi/platform.c
@@ -229,6 +229,14 @@ void platform_init(int argc, char **argv)
 	assert(gdb_if_init() == 0);
 }
 
+void platform_srst_set_val(bool assert)
+{
+	(void)assert;
+	platform_buffer_flush();
+}
+
+bool platform_srst_get_val(void) { return false; }
+
 void platform_buffer_flush(void)
 {
 	assert(ftdi_write_data(ftdic, outbuf, bufptr) == bufptr);

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -164,6 +164,18 @@ void platform_srst_set_val(bool assert)
 	} else {
 		gpio_set_val(SRST_PORT, SRST_PIN, !assert);
 	}
+	if (assert) {
+		for(int i = 0; i < 10000; i++) asm("nop");
+	}
+}
+
+bool platform_srst_get_val(void)
+{
+	if (platform_hwversion() == 0) {
+		return gpio_get(SRST_PORT, SRST_SENSE_PIN) == 0;
+	} else {
+		return gpio_get(SRST_PORT, SRST_PIN) == 0;
+	}
 }
 
 bool platform_target_get_power(void)

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -80,6 +80,7 @@
 #define PWR_BR_PIN	GPIO1
 #define SRST_PORT	GPIOA
 #define SRST_PIN	GPIO2
+#define SRST_SENSE_PIN	GPIO7
 
 #define USB_PU_PORT	GPIOA
 #define USB_PU_PIN	GPIO8
@@ -110,9 +111,6 @@
 #define UART_PIN_SETUP() \
 	gpio_set_mode(USBUSART_PORT, GPIO_MODE_OUTPUT_2_MHZ, \
 	              GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, USBUSART_TX_PIN);
-
-#define SRST_SET_VAL(x) \
-	platform_srst_set_val(x)
 
 #define USB_DRIVER stm32f103_usb_driver
 #define USB_IRQ    NVIC_USB_LP_CAN_RX0_IRQ

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -118,6 +118,13 @@ void platform_srst_set_val(bool assert)
 		gpio_set(SRST_PORT, pin);
 }
 
+bool platform_srst_get_val()
+{
+	uint16_t pin;
+	pin = platform_hwversion() == 0 ? SRST_PIN_V1 : SRST_PIN_V2;
+	return gpio_get(SRST_PORT, pin) == 0;
+}
+
 const char *platform_target_voltage(void)
 {
 	return "unknown";

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -98,9 +98,6 @@
 	gpio_set_mode(USBUSART_PORT, GPIO_MODE_OUTPUT_2_MHZ, \
 	              GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, USBUSART_TX_PIN);
 
-#define SRST_SET_VAL(x) \
-	platform_srst_set_val(x)
-
 #define USB_DRIVER      stm32f103_usb_driver
 #define USB_IRQ	        NVIC_USB_LP_CAN_RX0_IRQ
 #define USB_ISR	        usb_lp_can_rx0_isr

--- a/src/platforms/stm32/jtagtap.c
+++ b/src/platforms/stm32/jtagtap.c
@@ -50,19 +50,6 @@ void jtagtap_reset(void)
 	jtagtap_soft_reset();
 }
 
-void jtagtap_srst(bool assert)
-{
-	(void)assert;
-#ifdef SRST_SET_VAL
-	SRST_SET_VAL(assert);
-	if(assert) {
-		int i;
-		for(i = 0; i < 10000; i++)
-			asm volatile("nop");
-	}
-#endif
-}
-
 inline uint8_t jtagtap_next(uint8_t dTMS, uint8_t dTDO)
 {
 	uint16_t ret;

--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -84,6 +84,9 @@ void platform_init(void)
 	usbuart_init();
 }
 
+void platform_srst_set_val(bool assert) { (void)assert; }
+bool platform_srst_get_val(void) { return false; }
+
 const char *platform_target_voltage(void)
 {
 	return "unknown";

--- a/src/platforms/tm4c/jtagtap.c
+++ b/src/platforms/tm4c/jtagtap.c
@@ -25,18 +25,6 @@ jtagtap_reset(void)
 	jtagtap_soft_reset();
 }
 
-void
-jtagtap_srst(bool assert)
-{
-	volatile int i;
-	if (assert) {
-		gpio_clear(SRST_PORT, SRST_PIN);
-		for(i = 0; i < 10000; i++) asm("nop");
-	} else {
-		gpio_set(SRST_PORT, SRST_PIN);
-	}
-}
-
 uint8_t
 jtagtap_next(const uint8_t dTMS, const uint8_t dTDO)
 {

--- a/src/samd.c
+++ b/src/samd.c
@@ -426,7 +426,7 @@ bool samd_probe(target *t)
 	target_add_commands(t, samd_cmd_list, "SAMD");
 
 	/* If we're not in reset here */
-	if (!connect_assert_srst) {
+	if (!platform_srst_get_val()) {
 		/* We'll have to release the target from
 		 * extended reset to make attach possible */
 		if (target_mem_read32(t, SAMD_DSU_CTRLSTAT) &

--- a/src/target.c
+++ b/src/target.c
@@ -22,7 +22,6 @@
 #include "target.h"
 
 target *target_list = NULL;
-bool connect_assert_srst;
 
 target *target_new(unsigned size)
 {


### PR DESCRIPTION
- Remove connect_assert_srst global.
- Attach functions always release reset.
- Platforms provide a method to poll the reset pin.
- Reset on scan is all internal to command.c
- Reset is released on a failed scan.  Fixes #111