### PR TITLE
BMPM V2 target power control GPIO needs to be an open drain drive.

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -135,10 +135,14 @@ void platform_init(void)
 
 	/* Enable internal pull-up on PWR_BR so that we don't drive
 	   TPWR locally or inadvertently supply power to the target. */
-	if (platform_hwversion () > 0) {
-		gpio_set (PWR_BR_PORT, PWR_BR_PIN);
+	if (platform_hwversion () == 1) {
+		gpio_set(PWR_BR_PORT, PWR_BR_PIN);
 		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_INPUT,
 		              GPIO_CNF_INPUT_PULL_UPDOWN, PWR_BR_PIN);
+	} else if (platform_hwversion() > 1) {
+		gpio_set(PWR_BR_PORT, PWR_BR_PIN);
+		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_OUTPUT_50_MHZ,
+		              GPIO_CNF_OUTPUT_OPENDRAIN, PWR_BR_PIN);
 	}
 
 	if (platform_hwversion() > 0) {


### PR DESCRIPTION
BMPM V2 uses a biasing resistor for the true switch mosfet circuit.
Because of that the weak pull-up/down of the stm32 is not asserting the
correct gate voltage for the mosfets to fully switch through. Because of
that we need to use open drain configulation of the GPIO instead.