### PR TITLE
Presetting the connect_srst setting to false.

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -68,7 +68,7 @@ const struct command_s cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static bool connect_assert_srst;
+static bool connect_assert_srst = false;
 
 int command_process(target *t, char *cmd)
 {


### PR DESCRIPTION
If we do not explicitly set it to something it might end up with some
random ram value.