### PR TITLE
Added black magic verbose/debug mode switch.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
 PROBE_HOST ?= native
 PLATFORM_DIR = platforms/$(PROBE_HOST)
 VPATH += platforms/common $(PLATFORM_DIR)
+ENABLE_DEBUG ?=
 
 ifneq ($(V), 1)
 MAKEFLAGS += --no-print-dir
@@ -11,7 +12,11 @@ OPT_FLAGS ?= -O2
 
 CFLAGS += -Wall -Wextra -Werror -Wno-char-subscripts\
 	$(OPT_FLAGS) -std=gnu99 -g3 -MD \
-	-I. -Iinclude -Iplatforms/common -I$(PLATFORM_DIR) \
+	-I. -Iinclude -Iplatforms/common -I$(PLATFORM_DIR)
+
+ifeq ($(ENABLE_DEBUG), 1)
+CFLAGS += -DENABLE_DEBUG
+endif
 
 SRC =			\
 	adiv5.c		\

--- a/src/adiv5_swdp.c
+++ b/src/adiv5_swdp.c
@@ -29,6 +29,7 @@
 #include "jtagtap.h"
 #include "command.h"
 #include "morse.h"
+#include "gdb_packet.h"
 
 #define SWDP_ACK_OK    0x01
 #define SWDP_ACK_WAIT  0x02

--- a/src/command.c
+++ b/src/command.c
@@ -50,6 +50,9 @@ static bool cmd_target_power(target *t, int argc, const char **argv);
 #ifdef PLATFORM_HAS_TRACESWO
 static bool cmd_traceswo(void);
 #endif
+#ifdef PLATFORM_HAS_DEBUG
+static bool cmd_debug_bmp(target *t, int argc, const char **argv);
+#endif
 
 const struct command_s cmd_list[] = {
 	{"version", (cmd_handler)cmd_version, "Display firmware version info"},
@@ -65,10 +68,16 @@ const struct command_s cmd_list[] = {
 #ifdef PLATFORM_HAS_TRACESWO
 	{"traceswo", (cmd_handler)cmd_traceswo, "Start trace capture" },
 #endif
+#ifdef PLATFORM_HAS_DEBUG
+	{"debug_bmp", (cmd_handler)cmd_debug_bmp, "Output BMP \"debug\" strings to the second vcom: (enable|disable)"},
+#endif
 	{NULL, NULL, NULL}
 };
 
 static bool connect_assert_srst;
+#ifdef PLATFORM_HAS_DEBUG
+bool debug_bmp;
+#endif
 
 int command_process(target *t, char *cmd)
 {
@@ -276,3 +285,15 @@ static bool cmd_traceswo(void)
 }
 #endif
 
+#ifdef PLATFORM_HAS_DEBUG
+static bool cmd_debug_bmp(target *t, int argc, const char **argv)
+{
+	(void)t;
+	if (argc > 1) {
+		debug_bmp = !strcmp(argv[1], "enable");
+	}
+	gdb_outf("Debug mode is %s\n",
+		 debug_bmp ? "enabled" : "disabled");
+	return true;
+}
+#endif

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -29,6 +29,10 @@
 
 #define PLATFORM_HAS_TRACESWO
 #define PLATFORM_HAS_POWER_SWITCH
+#ifdef ENABLE_DEBUG
+#define PLATFORM_HAS_DEBUG
+#define USBUART_DEBUG
+#endif
 #define BOARD_IDENT             "Black Magic Probe"
 #define BOARD_IDENT_DFU	        "Black Magic Probe (Upgrade)"
 #define BOARD_IDENT_UPD	        "Black Magic Probe (DFU Upgrade)"
@@ -142,7 +146,14 @@
 #define TRACE_IRQ   NVIC_TIM3_IRQ
 #define TRACE_ISR   tim3_isr
 
+#ifdef ENABLE_DEBUG
+extern bool debug_bmp;
+void usbuart_debug_outf(const char *fmt, ...);
+
+#define DEBUG(...) if (debug_bmp) {usbuart_debug_outf("bmp: ");usbuart_debug_outf(__VA_ARGS__);}
+#else
 #define DEBUG(...)
+#endif
 
 #define SET_RUN_STATE(state)	{running_status = (state);}
 #define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, LED_IDLE_RUN, state);}
@@ -155,4 +166,3 @@
 #define vasprintf vasiprintf
 
 #endif
-

--- a/src/platforms/stm32/jtagtap.c
+++ b/src/platforms/stm32/jtagtap.c
@@ -24,6 +24,7 @@
 
 #include "general.h"
 #include "jtagtap.h"
+#include "gdb_packet.h"
 
 int jtagtap_init(void)
 {
@@ -60,7 +61,7 @@ inline uint8_t jtagtap_next(uint8_t dTMS, uint8_t dTDO)
 	ret = gpio_get(TDO_PORT, TDO_PIN);
 	gpio_clear(TCK_PORT, TCK_PIN);
 
-	DEBUG("jtagtap_next(TMS = %d, TDO = %d) = %d\n", dTMS, dTDO, ret);
+	//DEBUG("jtagtap_next(TMS = %d, TDO = %d) = %d\n", dTMS, dTDO, ret);
 
 	return ret != 0;
 }


### PR DESCRIPTION
The upcoming CID/PID tables rely on this code.

The way it is implemented it could probably be made more generic and usable on other platforms too. I do not want to have it enabled everywhere because I am not sure that it will not surpass their flash memory budget, this is why it is native platform only.