### PR TITLE
    ° add support for ITCM flash memory (in addition of DTCM) for STM…

### DIFF
--- a/src/stm32f4.c
+++ b/src/stm32f4.c
@@ -181,9 +181,28 @@ bool stm32f4_probe(target *t)
 		t->driver = stm32f7_driver_str;
 		target_add_ram(t, 0x00000000, 0x4000);
 		target_add_ram(t, 0x20000000, 0x50000);
+		/* DTCM */
 		stm32f4_add_flash(t, 0x8000000, 0x20000, 0x8000, 0);
 		stm32f4_add_flash(t, 0x8020000, 0x20000, 0x20000, 4);
 		stm32f4_add_flash(t, 0x8040000, 0xC0000, 0x40000, 5);
+		/* ITCM */
+		stm32f4_add_flash(t, 0x0200000, 0x20000, 0x8000, 0);
+		stm32f4_add_flash(t, 0x0220000, 0x20000, 0x20000, 4);
+		stm32f4_add_flash(t, 0x0240000, 0xC0000, 0x40000, 5);
+		target_add_commands(t, stm32f4_cmd_list, "STM32F7");
+		break;
+	case 0x451: /* F76x F77x RM0410 */
+		t->driver = stm32f7_driver_str;
+		target_add_ram(t, 0x00000000, 0x4000);
+		target_add_ram(t, 0x20000000, 0x80000);
+		/* DTCM */
+		stm32f4_add_flash(t, 0x8000000, 0x020000, 0x8000, 0);
+		stm32f4_add_flash(t, 0x8020000, 0x020000, 0x20000, 4);
+		stm32f4_add_flash(t, 0x8040000, 0x1C0000, 0x40000, 5);
+		/* ITCM */
+		stm32f4_add_flash(t, 0x200000, 0x020000, 0x8000, 0);
+		stm32f4_add_flash(t, 0x220000, 0x020000, 0x20000, 4);
+		stm32f4_add_flash(t, 0x240000, 0x1C0000, 0x40000, 5);
 		target_add_commands(t, stm32f4_cmd_list, "STM32F7");
 		break;
 	default:


### PR DESCRIPTION
° add support for new STM32F76x and STM32F77x MCU.
   theses MCU have 512Ko ram,  2Mo ITCM flash, 2Mo DTCM flash, double precision FPU
° add support for ITCM memory for  the two STM32F7 families (this permit flash and debug of chibios 3.x application)