### PR TITLE
Adding new ConfigID value for nRF52832 QFAA B00

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -161,6 +161,7 @@ bool nrf51_probe(target *t)
 		target_add_commands(t, nrf51_cmd_list, "nRF51");
 		return true;
 	case 0x00AC: /* nRF52832 Preview QFAA BA0 */
+    	case 0x00C7: /* nRF52832 Revision 1 QFAA B00 */
 		t->driver = "Nordic nRF52";
 		target_add_ram(t, 0x20000000, 64*1024);
 		nrf51_add_flash(t, 0x00000000, 512*1024, NRF52_PAGE_SIZE);


### PR DESCRIPTION
This is just another update for the Config ID value that has changed for the nRF52 Revision 1 QFAA B00.  It has been built and upgraded on a BMP v2.  I am still looking into using the INFO.PART factory information register as a better long term solution, and will make a followup commit if that is better way to go.