### PR TITLE
Add support for nRF51822QFAAH1

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -127,6 +127,7 @@ bool nrf51_probe(target *t)
 	case 0x0073: /* nRF51422 (rev 3) QFAA F0 */
 	case 0x0079: /* nRF51822 (rev 3) CEAA E0 */
 	case 0x007A: /* nRF51422 (rev 3) CEAA C0 */
+	case 0x008F: /* nRF51822 (rev 3) QFAA H1 See https://devzone.nordicsemi.com/question/97769/can-someone-conform-the-config-id-code-for-the-nrf51822qfaah1/ */
 		t->driver = "Nordic nRF51";
 		target_add_ram(t, 0x20000000, 0x4000);
 		nrf51_add_flash(t, 0x00000000, 0x40000, NRF51_PAGE_SIZE);


### PR DESCRIPTION
I found that I could not program a new batch of nRF51822 devices, and tracked down the problem to them containing a new revision of device QFAAH1, which I confirmed with Nordic as having ConfigID code 0x008F
See https://devzone.nordicsemi.com/question/97769/can-someone-conform-the-config-id-code-for-the-nrf51822qfaah1/

