### PR TITLE
Compile fixes

### DIFF
--- a/src/platforms/common/timing.h
+++ b/src/platforms/common/timing.h
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __TIMING__H
+#ifndef __TIMING_H
 #define __TIMING_H
 
 struct platform_timeout {
@@ -26,5 +26,5 @@ struct platform_timeout {
 
 uint32_t platform_time_ms(void);
 
-#endif
+#endif /* __TIMING_H */
 

--- a/src/platforms/stm32/usbdfu.h
+++ b/src/platforms/stm32/usbdfu.h
@@ -17,6 +17,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __USBDFU_H
+#define __USBDFU_H
+
 #include <libopencm3/usb/usbd.h>
 
 /* Commands sent with wBlockNum == 0 as per ST implementation. */
@@ -44,3 +47,4 @@ void dfu_event(void);
 /* Platform specific function */
 void dfu_detach(void);
 
+#endif /* __USBDFU_H */

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -78,7 +78,7 @@ enum cid_class {
 
 #ifdef PLATFORM_HAS_DEBUG
 /* The reserved ones only have an R in them, to save a bit of space. */
-static const char const *cidc_debug_strings[] =
+static const char * const cidc_debug_strings[] =
 {
 	[cidc_gvc] =     "Generic verification component",           /* 0x0 */
 	[cidc_romtab] =  "ROM Table",                                /* 0x1 */


### PR DESCRIPTION
Correct/add #include guards.
Correct the const declaration to achieve the intended behavior. (as a side note clang manages to spot this and complain about double const, we might want to add clang at least for the ftdi target in the CI run)