### PR TITLE
STM32L4: Use buffered flash model.

### DIFF
--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -131,8 +131,10 @@ static void stm32l4_add_flash(target *t,
 	f->length = length;
 	f->blocksize = blocksize;
 	f->erase = stm32l4_flash_erase;
-	f->write = stm32l4_flash_write;
-	f->align = 8;
+	f->write = target_flash_write_buffered;
+	f->done = target_flash_done_buffered;
+	f->write_buf = stm32l4_flash_write;
+	f->buf_size = 2048;
 	f->erased = 0xff;
 	sf->bank1_start = bank1_start;
 	target_add_flash(t, f);


### PR DESCRIPTION
Fixes #149 