### PR TITLE
add STM32F303 targets

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -133,7 +133,9 @@ bool stm32f1_probe(target *t)
 		return true;
 	case 0x422:  /* STM32F30x */
 	case 0x432:  /* STM32F37x */
+	case 0x438:  /* STM32F303x6/8 and STM32F328 */
 	case 0x439:  /* STM32F302C8 */
+	case 0x446:  /* STM32F303xD/E and STM32F398xE */
 		t->driver = "STM32F3";
 		target_add_ram(t, 0x20000000, 0x10000);
 		stm32f1_add_flash(t, 0x8000000, 0x80000, 0x800);
@@ -307,7 +309,9 @@ static bool stm32f1_cmd_option(target *t, int argc, char *argv[])
 	switch(t->idcode) {
 	case 0x422:  /* STM32F30x */
 	case 0x432:  /* STM32F37x */
+	case 0x438:  /* STM32F303x6/8 and STM32F328 */
 	case 0x440:  /* STM32F0 */
+	case 0x446:  /* STM32F303xD/E and STM32F398xE */
 		flash_obp_rdp_key = FLASH_OBP_RDP_KEY_F3;
 		break;
 	default: flash_obp_rdp_key = FLASH_OBP_RDP_KEY;


### PR DESCRIPTION
Adds ID codes for the STM32F303 targets.

Values are taken from [RM0316](http://www.st.com/resource/en/reference_manual/DM00043574.pdf), section 33.6.1.