### PR TITLE
Actual pin mappings and the comment differ!

### DIFF
--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -49,11 +49,11 @@
  * TPWR = 	RB0 (input) -- analogue on mini design ADC1, ch8
  * nTRST = 	PB1
  * SRST_OUT = 	PA2
- * TDI = 	PA3
- * TMS = 	PA4 (input for SWDP)
+ * TDI = 	PA7
+ * TMS = 	PB14 (input for SWDP)
  * TCK = 	PA5
  * TDO = 	PA6 (input)
- * nSRST = 	PA7 (input)
+ * nSRST = 	PB0 (input)
  *
  * USB cable pull-up: PA8
  * USB VBUS detect:  PB13 -- New on mini design.


### PR DESCRIPTION
I was stuck trying to debug the issue why my probe would not find any attached targets. This is because I was doing the pin mapping as per the comments, and not the actual code. There is a mismatch!

This PR updates the comment to reflect the values set in code. :)