### PR TITLE
STM32F7: Declare ITCM flash regions as ROM

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -179,28 +179,24 @@ bool stm32f4_probe(target *t)
 		t->driver = stm32f7_driver_str;
 		target_add_ram(t, 0x00000000, 0x4000);
 		target_add_ram(t, 0x20000000, 0x50000);
-		/* DTCM */
+		/* AXIM Flash access */
 		stm32f4_add_flash(t, 0x8000000, 0x20000, 0x8000, 0);
 		stm32f4_add_flash(t, 0x8020000, 0x20000, 0x20000, 4);
 		stm32f4_add_flash(t, 0x8040000, 0xC0000, 0x40000, 5);
 		/* ITCM */
-		stm32f4_add_flash(t, 0x0200000, 0x20000, 0x8000, 0);
-		stm32f4_add_flash(t, 0x0220000, 0x20000, 0x20000, 4);
-		stm32f4_add_flash(t, 0x0240000, 0xC0000, 0x40000, 5);
+		target_add_rom(t, 0x0200000, 0x100000);
 		target_add_commands(t, stm32f4_cmd_list, "STM32F7");
 		break;
 	case 0x451: /* F76x F77x RM0410 */
 		t->driver = stm32f7_driver_str;
 		target_add_ram(t, 0x00000000, 0x4000);
 		target_add_ram(t, 0x20000000, 0x80000);
-		/* DTCM */
+		/* AXIM Flash access */
 		stm32f4_add_flash(t, 0x8000000, 0x020000, 0x8000, 0);
 		stm32f4_add_flash(t, 0x8020000, 0x020000, 0x20000, 4);
 		stm32f4_add_flash(t, 0x8040000, 0x1C0000, 0x40000, 5);
 		/* ITCM */
-		stm32f4_add_flash(t, 0x200000, 0x020000, 0x8000, 0);
-		stm32f4_add_flash(t, 0x220000, 0x020000, 0x20000, 4);
-		stm32f4_add_flash(t, 0x240000, 0x1C0000, 0x40000, 5);
+		target_add_rom(t, 0x200000, 0x200000);
 		target_add_commands(t, stm32f4_cmd_list, "STM32F7");
 		break;
 	default:

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -127,6 +127,17 @@ void target_add_ram(target *t, target_addr start, uint32_t len)
 	ram->start = start;
 	ram->length = len;
 	ram->next = t->ram;
+	ram->readonly = false;
+	t->ram = ram;
+}
+
+void target_add_rom(target *t, target_addr start, uint32_t len)
+{
+	struct target_ram *ram = malloc(sizeof(*ram));
+	ram->start = start;
+	ram->length = len;
+	ram->next = t->ram;
+	ram->readonly = true;
 	t->ram = ram;
 }
 
@@ -139,8 +150,9 @@ void target_add_flash(target *t, struct target_flash *f)
 
 static ssize_t map_ram(char *buf, size_t len, struct target_ram *ram)
 {
-	return snprintf(buf, len, "<memory type=\"ram\" start=\"0x%08"PRIx32
+	return snprintf(buf, len, "<memory type=\"%s\" start=\"0x%08"PRIx32
 	                          "\" length=\"0x%"PRIx32"\"/>",
+							  ram->readonly ? "rom" : "ram",
 	                          ram->start, (uint32_t)ram->length);
 }
 

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -27,6 +27,7 @@ target *target_new(void);
 struct target_ram {
 	target_addr start;
 	size_t length;
+	bool readonly;
 	struct target_ram *next;
 };
 
@@ -130,6 +131,7 @@ struct target_s {
 
 void target_add_commands(target *t, const struct command_s *cmds, const char *name);
 void target_add_ram(target *t, target_addr start, uint32_t len);
+void target_add_rom(target *t, target_addr start, uint32_t len);
 void target_add_flash(target *t, struct target_flash *f);
 int target_flash_write_buffered(struct target_flash *f,
                                 target_addr dest, const void *src, size_t len);


### PR DESCRIPTION
- Add support for ROM regions in target memory map
- Register ITCM flash regions as ROM

Suggested fix for #188 