### PR TITLE
cortexm: Check halt reason on stub exit.

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -633,9 +633,16 @@ int cortexm_run_stub(target *t, uint32_t loadaddr,
 		return -1;
 
 	/* Execute the stub */
+	enum target_halt_reason reason;
 	cortexm_halt_resume(t, 0);
-	while (!cortexm_halt_poll(t, NULL))
+	while ((reason = cortexm_halt_poll(t, NULL)) == TARGET_HALT_RUNNING)
 		;
+
+	if (reason == TARGET_HALT_ERROR)
+		raise_exception(EXCEPTION_ERROR, "Target lost in stub");
+
+	if (reason != TARGET_HALT_BREAKPOINT)
+		return -2;
 
 	uint32_t pc = cortexm_pc_read(t);
 	uint16_t bkpt_instr = target_mem_read16(t, pc);


### PR DESCRIPTION
This fixes an bug, where if the target was lost while polling the stub, the already free'd target
would be interrogated to check for the breakpoint instruction.  This would result in a crash in the firmware.

This is at least a partial fix for #185 and #191.  There may be other issues causing us to loose the target.