### PR TITLE
Increase st-link flash allowance to 128K.

### DIFF
--- a/src/platforms/stm32/stlink.ld
+++ b/src/platforms/stm32/stlink.ld
@@ -20,7 +20,7 @@
 /* Define memory regions. */
 MEMORY
 {
-	rom (rx) : ORIGIN = 0x08000000, LENGTH =  64K
+	rom (rx) : ORIGIN = 0x08000000, LENGTH =  128K
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
 }
 


### PR DESCRIPTION
Although the devices are only documented to have 64K flash,
they have been obeserved to have a full 128K, although the undocumented
half may be untested and have problems.