### PR TITLE
K22F security hack

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -176,6 +176,7 @@ void platform_init(void)
 
 void platform_srst_set_val(bool assert)
 {
+	gpio_set_val(TMS_PORT, TMS_PIN, 1);
 	if ((platform_hwversion() == 0) ||
 	    (platform_hwversion() >= 3)) {
 		gpio_set_val(SRST_PORT, SRST_PIN, assert);


### PR DESCRIPTION
- Write unsecured value to flash in 'done' handler if it hasn't been programmed.
- Drive TMS high during reset to avoid enabling EzPort (and disabling the micro)