### PR TITLE
fixed a bug in the breakpoint removal code

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -355,7 +355,7 @@ int target_breakwatch_clear(target *t,
 {
 	struct breakwatch *bwp = NULL, *bw;
 	int ret = 1;
-	for (bw = t->bw_list; bw; bw = bw->next, bwp = bw)
+	for (bw = t->bw_list; bw; bwp = bw, bw = bw->next)
 		if ((bw->type == type) &&
 		    (bw->addr == addr) &&
 		    (bw->size == len))


### PR DESCRIPTION
The order of the expressions in the 'for' loop increment part is reversed, and the code may break depending on the order in which breakpoints are inserted and removed. Apparently, GDB inserts and removes breakpoints in the 'right' order, so the problem is not triggered, but in the case of a debugger that I am writing, things break badly and the BMP gets into a hard fault