### PR TITLE
RFC: i.MX 7 support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -34,6 +34,7 @@ SRC =			\
 	gdb_hostio.c	\
 	gdb_packet.c	\
 	hex_utils.c	\
+	imx7.c	\
 	jtag_scan.c	\
 	jtagtap.c	\
 	jtagtap_generic.c	\

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -364,9 +364,9 @@ ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel)
 	if(!tmpap.idr) /* IDR Invalid - Should we not continue here? */
 		return NULL;
 
-	/* It's valid to so create a heap copy */
+	/* Create a heap copy */
 	ap = malloc(sizeof(*ap));
-	memcpy(ap, &tmpap, sizeof(*ap));
+	*ap = tmpap;
 	adiv5_dp_ref(dp);
 
 	ap->cfg = adiv5_ap_read(ap, ADIV5_AP_CFG);

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -239,7 +239,7 @@ void adiv5_dp_write(ADIv5_DP_t *dp, uint16_t addr, uint32_t value)
 	dp->low_access(dp, ADIV5_LOW_WRITE, addr, value);
 }
 
-static uint32_t adiv5_mem_read32(ADIv5_AP_t *ap, uint32_t addr)
+uint32_t adiv5_mem_read32(ADIv5_AP_t *ap, uint32_t addr)
 {
 	uint32_t ret;
 	adiv5_mem_read(ap, &ret, addr, sizeof(ret));
@@ -294,6 +294,10 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
 				break;
 
 			if ((entry & 1) == 0)
+				continue;
+
+			if (ap->dp->rom_table_filter &&
+			    ap->dp->rom_table_filter(addr + (entry & ~0xfff)))
 				continue;
 
 			adiv5_component_probe(ap, addr + (entry & ~0xfff));
@@ -440,6 +444,9 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 
 		extern void kinetis_mdm_probe(ADIv5_AP_t *);
 		kinetis_mdm_probe(ap);
+
+		extern void imx7_ahb_probe(ADIv5_AP_t *);
+		imx7_ahb_probe(ap);
 
 		if (ap->base == 0xffffffff) {
 			/* No debug entries... useless AP */

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -116,6 +116,8 @@ typedef struct ADIv5_DP_s {
 		jtag_dev_t *dev;
 		uint8_t fault;
 	};
+
+	bool (*rom_table_filter)(uint32_t addr);
 } ADIv5_DP_t;
 
 static inline uint32_t adiv5_dp_read(ADIv5_DP_t *dp, uint16_t addr)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -254,6 +254,10 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 #define PROBE(x) \
 	do { if ((x)(t)) return true; else target_check_error(t); } while (0)
 
+	/* imx7m4_probe needs to be before stm32f1_probe since the i.MX 7
+	 * crashes when stm32f1_probe tries to identify itself
+	 */
+	PROBE(imx7m4_probe);
 	PROBE(stm32f1_probe);
 	PROBE(stm32f4_probe);
 	PROBE(stm32l0_probe);   /* STM32L0xx & STM32L1xx */

--- a/src/target/imx7.c
+++ b/src/target/imx7.c
@@ -1,0 +1,86 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This file implements NXP i.MX 7Solo/Dual detection and reset.
+ *
+ * Reference:
+ * - MX7DRM, Rev. 0.1, 08/2016
+ * - SoC detection from U-Boot v2016.11
+ */
+
+#include "general.h"
+#include "target.h"
+#include "target_internal.h"
+#include "cortexm.h"
+
+#define CCM_ANALOG_DIGPROG	0x30360800
+
+#define SRC_M4RCR		0x3039000C
+#define SRC_M4RCR_SW_M4C_NON_SCLR_RST	(0x1 << 0)
+#define SRC_M4RCR_SW_M4C_RST		(0x1 << 1)
+
+static void imx7m4_extended_reset(target *t);
+static bool imx7m4_attach(target *t);
+
+bool imx7m4_probe(target *t)
+{
+	t->idcode = (target_mem_read32(t, CCM_ANALOG_DIGPROG) >> 16) & 0xff;
+	switch(t->idcode) {
+	case 0x72:
+		t->driver = "i.MX 7Solo/Dual ARM Cortex-M4";
+		t->extended_reset = imx7m4_extended_reset;
+		t->attach = imx7m4_attach;
+		target_add_ram(t, 0x00000000, 0x8000); /* OCRAM_S ALIAS CODE */
+		target_add_ram(t, 0x00180000, 0x8000); /* OCRAM_S */
+		target_add_ram(t, 0x00900000, 0x20000); /* OCRAM ALIAS CODE */
+		target_add_ram(t, 0x1fff8000, 0x8000); /* TCML */
+		target_add_ram(t, 0x20000000, 0x8000); /* TCMU */
+		target_add_ram(t, 0x20200000, 0x20000); /* OCRAM */
+		target_add_ram(t, 0x80000000, 0x60000000); /* DDR */
+
+		return true;
+	}
+
+	return false;
+}
+
+static void
+imx7m4_extended_reset(target *t)
+{
+	uint32_t val;
+
+	/* Reset Cortex-M4 core */
+	val = target_mem_read32(t, SRC_M4RCR);
+	val |= SRC_M4RCR_SW_M4C_RST;
+	target_mem_write32(t, SRC_M4RCR, val);
+}
+
+static bool imx7m4_attach(target *t)
+{
+	uint32_t val;
+
+	/* Take Cortex-M4 core out of non-clearing reset */
+	val = target_mem_read32(t, SRC_M4RCR);
+	val &= ~SRC_M4RCR_SW_M4C_NON_SCLR_RST;
+	target_mem_write32(t, SRC_M4RCR, val);
+
+	return cortexm_attach(t);
+}

--- a/src/target/imx7.c
+++ b/src/target/imx7.c
@@ -31,14 +31,52 @@
 #include "target_internal.h"
 #include "cortexm.h"
 
+#define IMX7_AHP_AP_IDR		0x64770001
+
 #define CCM_ANALOG_DIGPROG	0x30360800
+
+#define SRC_A7RCR1		0x30390008
+#define SRC_A7RCR1_A7_CORE1_ENABLE	(0x1 << 1)
 
 #define SRC_M4RCR		0x3039000C
 #define SRC_M4RCR_SW_M4C_NON_SCLR_RST	(0x1 << 0)
 #define SRC_M4RCR_SW_M4C_RST		(0x1 << 1)
 
+static bool imx7_rom_table_filter(uint32_t addr);
+extern uint32_t adiv5_mem_read32(ADIv5_AP_t *ap, uint32_t addr);
+
 static void imx7m4_extended_reset(target *t);
 static bool imx7m4_attach(target *t);
+
+void imx7_ahb_probe(ADIv5_AP_t *ap)
+{
+	uint32_t val;
+	switch(ap->idr) {
+	case IMX7_AHP_AP_IDR:
+		break;
+	default:
+		return;
+	}
+
+	val = adiv5_mem_read32(ap, SRC_A7RCR1);
+	if (!(val & SRC_A7RCR1_A7_CORE1_ENABLE)) {
+		DEBUG("i.MX 7 Secondary A7 core not enabled, installing ROM filter.\n");
+		ap->dp->rom_table_filter = imx7_rom_table_filter;
+	}
+}
+
+static bool imx7_rom_table_filter(uint32_t addr)
+{
+	switch (addr) {
+	case 0x80072000UL:
+	case 0x80073000UL:
+	case 0x8007d000UL:
+	case 0x80082000UL:
+		return true;
+	default:
+		return false;
+	}
+}
 
 bool imx7m4_probe(target *t)
 {

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -182,6 +182,7 @@ bool nrf51_probe(target *t);
 bool samd_probe(target *t);
 bool kinetis_probe(target *t);
 bool efm32_probe(target *t);
+bool imx7m4_probe(target *t);
 
 #endif
 


### PR DESCRIPTION
With this modifications I can successfully scan an i.MX 7Solo or Dual SoC:

    (gdb) monitor jtag_scan
    Target voltage: 3.3V
    Available Targets:
    No. Att Driver
     1      ARM Cortex-A
     2      i.MX 7Solo/Dual ARM Cortex-M4

Attaching the M4 core works too, even when the core is in reset (the targets attach function takes it out of reset). Attaching the A7 does not work currently.