### PR TITLE
Stlink V2 - generic clone "Baite"

### DIFF
--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -2,10 +2,12 @@ CROSS_COMPILE ?= arm-none-eabi-
 CC = $(CROSS_COMPILE)gcc
 OBJCOPY = $(CROSS_COMPILE)objcopy
 
+HWVERSION ?= detect
+
 OPT_FLAGS = -Os
 CFLAGS += -mcpu=cortex-m3 -mthumb \
-	-DSTM32F1 -DDISCOVERY_STLINK -I../libopencm3/include \
-	-I platforms/stm32
+	-DSTM32F1 -DDISCOVERY_STLINK -DHWVERSION=$(HWVERSION) \
+	-I../libopencm3/include -I platforms/stm32
 LDFLAGS_BOOT := $(LDFLAGS) --specs=nano.specs \
 	-lopencm3_stm32f1 -Wl,--defsym,_stack=0x20005000 \
 	-Wl,-T,platforms/stm32/stlink.ld -nostartfiles -lc -lnosys \

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -36,21 +36,29 @@
 uint8_t running_status;
 volatile uint32_t timeout_counter;
 
+#ifdef BAITE
+#pragma message "Compiled for Baite stlink"
+#endif
+
 uint16_t led_idle_run;
 /* Pins PC[14:13] are used to detect hardware revision. Read
  * 11 for STLink V1 e.g. on VL Discovery, tag as hwversion 0
  * 10 for STLink V2 e.g. on F4 Discovery, tag as hwversion 1
+ * CFLAGS += -DBAITE for Baite branded stlink v2, tag as hwversion 2
  */
 int platform_hwversion(void)
 {
 	static int hwversion = -1;
-	int i;
 	if (hwversion == -1) {
+		#ifdef BAITE
+		hwversion = 2;
+		#else
 		gpio_set_mode(GPIOC, GPIO_MODE_INPUT,
 		              GPIO_CNF_INPUT_PULL_UPDOWN, GPIO14 | GPIO13);
 		gpio_set(GPIOC, GPIO14 | GPIO13);
-		for (i = 0; i<10; i++)
+		for (int i = 0; i<10; i++)
 			hwversion = ~(gpio_get(GPIOC, GPIO14 | GPIO13) >> 13) & 3;
+		#endif
 		switch (hwversion)
 		{
 		case 0:

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -47,7 +47,6 @@ uint16_t led_idle_run;
 /* Pins PC[14:13] are used to detect hardware revision. Read
  * 11 for STLink V1 e.g. on VL Discovery, tag as hwversion 0
  * 10 for STLink V2 e.g. on F4 Discovery, tag as hwversion 1
- * CFLAGS += -DBAITE for Baite branded stlink v2, tag as hwversion 2
  */
 int platform_hwversion(void)
 {
@@ -84,14 +83,15 @@ void platform_init(void)
 		led_idle_run = GPIO8;
 		break;
 	case V2:
-	case Baite:
-	default:
 		led_idle_run = GPIO9;
-		/* On Rev 1 unconditionally activate MCO on PORTA8 with HSE */
+		/* On stlink V2 unconditionally activate MCO on PORTA8 with HSE */
 		RCC_CFGR &= ~(0xf << 24);
 		RCC_CFGR |= (RCC_CFGR_MCO_HSECLK << 24);
 		gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
 		GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO8);
+	case Baite:
+		led_idle_run = GPIO9;
+	default:
 	}
 
 	/* Setup GPIO ports */


### PR DESCRIPTION
I'm testing a stlink v2 clone branded "Baite" with blackmagic firmware. This appears to be a relatively common clone with multiple references / images of it when searching on google.
It was originally purchased from adafruit I believe.

Its layout is basically half way between the stlink V1 and V2, but unfortunately I was unable to find a method of detecting it automatically. 
As such I've added a compile time setting to allow overriding hw version detection and adding support for this programmers differences.

The basic differences of this hardware amount to: 
* using V2 led gpio (but with only a single led) 
* using V2 srst pin
* not needing MCO on PORTA8 with HSE like V2
* doesn't have correct wiring to be detected as V2

For more details: http://www.stm32duino.com/viewtopic.php?t=1357&start=10#p17455

This changeset can be used as such:
`make PROBE_HOST=stlink HWVERSION=Baite`
where `HWVERSION={V1, V2, Baite, detect}`  with default `detect` matching original functionality.
