### PR TITLE
Make Cortex M driver write DCCIMVAC prior to reading or writing each 32 bytes of RAM

### DIFF
--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -37,6 +37,9 @@
 #define CORTEXM_DCRDR		(CORTEXM_SCS_BASE + 0xDF8)
 #define CORTEXM_DEMCR		(CORTEXM_SCS_BASE + 0xDFC)
 
+/* Data cache clean and invalidate by address to the PoC=Point of Coherency */
+#define CORTEXM_DCCIMVAC	(CORTEXM_SCS_BASE + 0xF70)
+
 #define CORTEXM_FPB_BASE	(CORTEXM_PPB_BASE + 0x2000)
 
 /* ARM Literature uses FP_*, we use CORTEXM_FPB_* consistently */


### PR DESCRIPTION
Single stepping / tracing did not work properly with STM32F767, debugger couldn't see values of local variables etc. This turns out to be because the data cache was enabled so memory was out of date.

This gist demonstates the problem, I captured it before I debugged the issue and reported it on gitter:
https://gist.github.com/nickd4/ec8628c2ce90658c3efe44ead3d2116e
Looking at the register dump, it had just entered the function InitGraphics() and stored the value from r0 into pNewLCD (the name of the function parameter), r0 contained the correct value and r7+4 contained the correct address of pNewLCD and pc was the instruction just after the store... so p/x pNewLCD should have shown the same value as in r0, but it showed 0 instead, which was clearly incorrect.

The problem went away when I disabled the D-cache but this was clearly unsatisfactory so I looked up in the Cortex-M documentation how to flush the cache prior to accessing memory, here it is here:
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0646b/BABIGDDC.html
Out of this list, the most appropriate command in this situation seemed to be writing DCCIMVAC. So I tried this in gdb and it appeared to fix the problem, here is the gdb session demonstrating this:
https://gist.github.com/nickd4/222ea242febde0c6c35b8bffbea9ca75

Therefore, I incorporated this change into the Black Magic firmware, with several optimizations, firstly it only does it for RAM regions (I figure flash will never change and memory mapped registers are not cached), secondly it does 32 byte blocks since apparently only bits 31..5 of DCCIMVAC are significant.

I then captured a final gdb session with the revised firmware showing that it definitely fixes the problem:
https://gist.github.com/nickd4/bdb13234db7d3a12b60eeb27cc7606f5
