### PR TITLE
lm3s/tm4c: add TM4C1230C3PM

### DIFF
--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -89,6 +89,13 @@ bool lmi_probe(target *t)
 		 * only use the AIRCR SYSRESETREQ. */
 		t->target_options |= CORTEXM_TOPT_INHIBIT_SRST;
 		return true;
+
+	case 0x1022:    /* TM4C1230C3PM */
+		t->driver = lmi_driver_str;
+		target_add_ram(t, 0x20000000, 0x6000);
+		lmi_add_flash(t, 0x10000);
+		t->target_options |= CORTEXM_TOPT_INHIBIT_SRST;
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
This adds memory map information for TM4C1230C3PM.