### PR TITLE
Added NRF51_FICR_CONFIGID for nRF51822 QFAA H2

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -129,6 +129,7 @@ bool nrf51_probe(target *t)
 	case 0x0079: /* nRF51822 (rev 3) CEAA E0 */
 	case 0x007A: /* nRF51422 (rev 3) CEAA C0 */
 	case 0x008F: /* nRF51822 (rev 3) QFAA H1 See https://devzone.nordicsemi.com/question/97769/can-someone-conform-the-config-id-code-for-the-nrf51822qfaah1/ */
+	case 0x00D1: /* nRF51822 (rev 3) QFAA H2 */		
 		t->driver = "Nordic nRF51";
 		target_add_ram(t, 0x20000000, 0x4000);
 		nrf51_add_flash(t, 0x00000000, 0x40000, NRF51_PAGE_SIZE);


### PR DESCRIPTION
I have added the `NRF51_FICR_CONFIGID` value for nRF51822 QFAA H2.

Here's the picture of the chip and the output when I read the NRF51_FICR_CONFIGID memory location of the chip.

![chip picture](https://user-images.githubusercontent.com/10342017/29890698-d096cac0-8dc8-11e7-94be-a23de489d18c.jpg)

![gdb memory dump for nrf51_ficr_configid location](https://user-images.githubusercontent.com/10342017/29890625-921a6658-8dc8-11e7-8b81-12ac04110f88.png)