### PR TITLE
Add nRF52840 support (PCA10056, nrf52840 PDK)

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -164,10 +164,17 @@ bool nrf51_probe(target *t)
 		target_add_commands(t, nrf51_cmd_list, "nRF51");
 		return true;
 	case 0x00AC: /* nRF52832 Preview QFAA BA0 */
-    	case 0x00C7: /* nRF52832 Revision 1 QFAA B00 */
+	case 0x00C7: /* nRF52832 Revision 1 QFAA B00 */
 		t->driver = "Nordic nRF52";
 		target_add_ram(t, 0x20000000, 64*1024);
 		nrf51_add_flash(t, 0x00000000, 512*1024, NRF52_PAGE_SIZE);
+		nrf51_add_flash(t, NRF51_UICR, 0x100, 0x100);
+		target_add_commands(t, nrf51_cmd_list, "nRF52");
+		return true;
+	case 0x00EB: /* nRF52840 Preview QIAA AA0 */
+		t->driver = "Nordic nRF52";
+		target_add_ram(t, 0x20000000, 256*1024);
+		nrf51_add_flash(t, 0x00000000, 1024*1024, NRF52_PAGE_SIZE);
 		nrf51_add_flash(t, NRF51_UICR, 0x100, 0x100);
 		target_add_commands(t, nrf51_cmd_list, "nRF52");
 		return true;


### PR DESCRIPTION
Got one of the Preview Development Kits for the nRF52840 and got it running with black magic.
Just needs a few lines.
Thanks for your awesome tool!

Tested:
* flashing to main flash (UICR not tested)
* debugging
