### PR TITLE
add explicit fall through comment to eliminate GCC 7 implicit-fallthrough warning

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -156,6 +156,7 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 		case 's':	/* 's [addr]': Single step [start at addr] */
 			single_step = true;
 			// Fall through to resume target
+			/* fall through */
 		case 'c':	/* 'c [addr]': Continue [at addr] */
 			if(!cur_target) {
 				gdb_putpacketz("X1D");
@@ -166,6 +167,7 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 			SET_RUN_STATE(1);
 			single_step = false;
 			// Fall through to wait for target halt
+			/* fall through */
 		case '?': {	/* '?': Request reason for target halt */
 			/* This packet isn't documented as being mandatory,
 			 * but GDB doesn't work without it. */

--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -445,6 +445,7 @@ static int cdcacm_control_request(usbd_device *dev,
 		switch(req->wIndex) {
 		case 2:
 			usbuart_set_line_coding((struct usb_cdc_line_coding*)*buf);
+			/* fall through */
 		case 0:
 			return 1; /* Ignore on GDB Port */
 		default:
@@ -462,6 +463,7 @@ static int cdcacm_control_request(usbd_device *dev,
 
 			return 1;
 		}
+		/* fall through */
 	case DFU_DETACH:
 		if(req->wIndex == DFU_IF_NO) {
 			*complete = dfu_detach_complete;

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -190,11 +190,13 @@ bool stm32f4_probe(target *t)
 		stm32f4_add_flash(t, 0x8110000, 0x10000, 0x10000, 16);
 		stm32f4_add_flash(t, 0x8120000, 0xE0000, 0x20000, 17);
 		/* Fall through for stuff common to F40x/F41x */
+		/* fall through */
 	case ID_STM32F20X: /* F205 */
 	case ID_STM32F40X: /* F405 */
 		if (!f2)
 			target_add_ram(t, 0x10000000, 0x10000);
 		/* Fall through for devices w/o CCMRAM */
+		/* fall through */
 	case ID_STM32F446: /* F446 */
 	case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
 	case ID_STM32F411: /* F411     RM0383 Rev.4 */


### PR DESCRIPTION
this commit fixes #238 