### PR TITLE
fix *NULL when AP 0 is not present

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -265,7 +265,7 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
 	/* Assemble logical Component ID register value. */
 	for (int i = 0; i < 4; i++) {
 		uint32_t x = adiv5_mem_read32(ap, addr + CIDR0_OFFSET + 4*i);
-		cidr |= ((uint64_t)(x & 0xff)) << (i * 8);
+		cidr |= (x & 0xff) << (i * 8);
 	}
 
 	if (adiv5_dp_error(ap->dp)) {

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -344,6 +344,14 @@ static bool cortexa_check_error(target *t)
 	return err;
 }
 
+static void cortexa_priv_free(void *p)
+{
+	struct cortexa_priv *priv = p;
+	if (priv->ahb) {
+		adiv5_ap_unref(priv->ahb);
+	}
+	free(priv);
+}
 
 bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 {
@@ -353,14 +361,13 @@ bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 	adiv5_ap_ref(apb);
 	struct cortexa_priv *priv = calloc(1, sizeof(*priv));
 	t->priv = priv;
-	t->priv_free = free;
+	t->priv_free = cortexa_priv_free;
 	priv->apb = apb;
 
 	/* FIXME Find a better way to find the AHB.  This is likely to be
 	 * device specific. */
 	priv->ahb = adiv5_new_ap(apb->dp, 0);
 	if (priv->ahb) {
-		adiv5_ap_ref(priv->ahb);
 		if (false) {
 			/* FIXME: This used to be if ((priv->ahb->idr & 0xfffe00f) == 0x4770001)
 			 * Accessing memory directly through the AHB is much faster, but can


### PR DESCRIPTION
On my target adiv5_new_ap(, 0) returns NULL.

With this fix to what appears to be incomplete code I can access the CPU and memory. Without it the BMP locks up due to the referencing of a NULL priv->ahb