### PR TITLE
cortexa: Remove problematic code for AHB access.

### DIFF
--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -60,7 +60,6 @@ static uint32_t read_gpreg(target *t, uint8_t regno);
 struct cortexa_priv {
 	uint32_t base;
 	ADIv5_AP_t *apb;
-	ADIv5_AP_t *ahb;
 	struct {
 		uint32_t r[16];
 		uint32_t cpsr;
@@ -217,19 +216,6 @@ static uint32_t va_to_pa(target *t, uint32_t va)
 	return pa;
 }
 
-static void cortexa_mem_read(target *t, void *dest, target_addr src, size_t len)
-{
-	/* Clean cache before reading */
-	for (uint32_t cl = src & ~(CACHE_LINE_LENGTH-1);
-	     cl < src + len; cl += CACHE_LINE_LENGTH) {
-		write_gpreg(t, 0, cl);
-		apb_write(t, DBGITR, MCR | DCCMVAC);
-	}
-
-	ADIv5_AP_t *ahb = ((struct cortexa_priv*)t->priv)->ahb;
-	adiv5_mem_read(ahb, dest, va_to_pa(t, src), len);
-}
-
 static void cortexa_slow_mem_read(target *t, void *dest, target_addr src, size_t len)
 {
 	struct cortexa_priv *priv = t->priv;
@@ -267,18 +253,6 @@ static void cortexa_slow_mem_read(target *t, void *dest, target_addr src, size_t
 	} else {
 		apb_read(t, DBGDTRTX);
 	}
-}
-
-static void cortexa_mem_write(target *t, target_addr dest, const void *src, size_t len)
-{
-	/* Clean and invalidate cache before writing */
-	for (uint32_t cl = dest & ~(CACHE_LINE_LENGTH-1);
-	     cl < dest + len; cl += CACHE_LINE_LENGTH) {
-		write_gpreg(t, 0, cl);
-		apb_write(t, DBGITR, MCR | DCCIMVAC);
-	}
-	ADIv5_AP_t *ahb = ((struct cortexa_priv*)t->priv)->ahb;
-	adiv5_mem_write(ahb, va_to_pa(t, dest), src, len);
 }
 
 static void cortexa_slow_mem_write_bytes(target *t, target_addr dest, const uint8_t *src, size_t len)
@@ -338,8 +312,7 @@ static void cortexa_slow_mem_write(target *t, target_addr dest, const void *src,
 static bool cortexa_check_error(target *t)
 {
 	struct cortexa_priv *priv = t->priv;
-	ADIv5_AP_t *ahb = priv->ahb;
-	bool err = (ahb && (adiv5_dp_error(ahb->dp)) != 0) || priv->mmu_fault;
+	bool err = priv->mmu_fault;
 	priv->mmu_fault = false;
 	return err;
 }
@@ -355,25 +328,8 @@ bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 	t->priv = priv;
 	t->priv_free = free;
 	priv->apb = apb;
-	/* FIXME Find a better way to find the AHB.  This is likely to be
-	 * device specific. */
-	priv->ahb = adiv5_new_ap(apb->dp, 0);
-	adiv5_ap_ref(priv->ahb);
-	if (false) {
-		/* FIXME: This used to be if ((priv->ahb->idr & 0xfffe00f) == 0x4770001)
-		 * Accessing memory directly through the AHB is much faster, but can
-		 * result in data inconsistencies if the L2 cache is enabled.
-		 */
-		/* This is an AHB */
-		t->mem_read = cortexa_mem_read;
-		t->mem_write = cortexa_mem_write;
-	} else {
-		/* This is not an AHB, fall back to slow APB access */
-		adiv5_ap_unref(priv->ahb);
-		priv->ahb = NULL;
-		t->mem_read = cortexa_slow_mem_read;
-		t->mem_write = cortexa_slow_mem_write;
-	}
+	t->mem_read = cortexa_slow_mem_read;
+	t->mem_write = cortexa_slow_mem_write;
 
 	priv->base = debug_base;
 	/* Set up APB CSW, we won't touch this again */


### PR DESCRIPTION
The old code for 'fast' memory accesses using the AHB directly has problems with data consitency.  Until this can be resolved, I'm removing the affected code.

This should also fix #275 