### PR TITLE
Single register access - Target methods and GDB server support

### DIFF
--- a/src/include/target.h
+++ b/src/include/target.h
@@ -58,6 +58,8 @@ size_t target_regs_size(target *t);
 const char *target_tdesc(target *t);
 void target_regs_read(target *t, void *data);
 void target_regs_write(target *t, const void *data);
+ssize_t target_reg_read(target *t, int reg, void *data, size_t max);
+ssize_t target_reg_write(target *t, int reg, const void *data, size_t size);
 
 /* Halt/resume functions */
 enum target_halt_reason {

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -43,6 +43,9 @@ static void cortexa_regs_read(target *t, void *data);
 static void cortexa_regs_write(target *t, const void *data);
 static void cortexa_regs_read_internal(target *t);
 static void cortexa_regs_write_internal(target *t);
+static ssize_t cortexa_reg_read(target *t, int reg, void *data, size_t max);
+static ssize_t cortexa_reg_write(target *t, int reg, const void *data, size_t max);
+
 
 static void cortexa_reset(target *t);
 static enum target_halt_reason cortexa_halt_poll(target *t, target_addr *watch);
@@ -348,6 +351,8 @@ bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 	t->tdesc = tdesc_cortex_a;
 	t->regs_read = cortexa_regs_read;
 	t->regs_write = cortexa_regs_write;
+	t->reg_read = cortexa_reg_read;
+	t->reg_write = cortexa_reg_write;
 
 	t->reset = cortexa_reset;
 	t->halt_request = cortexa_halt_request;
@@ -457,6 +462,47 @@ static void cortexa_regs_write(target *t, const void *data)
 {
 	struct cortexa_priv *priv = (struct cortexa_priv *)t->priv;
 	memcpy(&priv->reg_cache, data, t->regs_size);
+}
+
+static ssize_t ptr_for_reg(target *t, int reg, void **r)
+{
+	struct cortexa_priv *priv = (struct cortexa_priv *)t->priv;
+	switch (reg) {
+	case 0 ... 15:
+		*r = &priv->reg_cache.r[reg];
+		return 4;
+	case 16:
+		*r = &priv->reg_cache.cpsr;
+		return 4;
+	case 17:
+		*r = &priv->reg_cache.fpscr;
+		return 4;
+	case 18 ... 33:
+		*r = &priv->reg_cache.d[reg - 18];
+		return 8;
+	default:
+		return -1;
+	}
+}
+
+static ssize_t cortexa_reg_read(target *t, int reg, void *data, size_t max)
+{
+	void *r = NULL;
+	size_t s = ptr_for_reg(t, reg, &r);
+	if (s > max)
+		return -1;
+	memcpy(data, r, s);
+	return s;
+}
+
+static ssize_t cortexa_reg_write(target *t, int reg, const void *data, size_t max)
+{
+	void *r = NULL;
+	size_t s = ptr_for_reg(t, reg, &r);
+	if (s > max)
+		return -1;
+	memcpy(r, data, s);
+	return s;
 }
 
 static void cortexa_regs_read_internal(target *t)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -50,6 +50,8 @@ const struct command_s cortexm_cmd_list[] = {
 static void cortexm_regs_read(target *t, void *data);
 static void cortexm_regs_write(target *t, const void *data);
 static uint32_t cortexm_pc_read(target *t);
+ssize_t cortexm_reg_read(target *t, int reg, void *data, size_t max);
+ssize_t cortexm_reg_write(target *t, int reg, const void *data, size_t max);
 
 static void cortexm_reset(target *t);
 static enum target_halt_reason cortexm_halt_poll(target *t, target_addr *watch);
@@ -225,6 +227,8 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	t->tdesc = tdesc_cortex_m;
 	t->regs_read = cortexm_regs_read;
 	t->regs_write = cortexm_regs_write;
+	t->reg_read = cortexm_reg_read;
+	t->reg_write = cortexm_reg_write;
 
 	t->reset = cortexm_reset;
 	t->halt_request = cortexm_halt_request;
@@ -410,6 +414,39 @@ static void cortexm_regs_write(target *t, const void *data)
 			                    ADIV5_AP_DB(DB_DCRSR),
 			                    0x10000 | regnum_cortex_mf[i]);
 		}
+}
+
+int dcrsr_regnum(target *t, unsigned reg)
+{
+	if (reg < sizeof(regnum_cortex_m) / 4) {
+		return regnum_cortex_m[reg];
+	} else if ((t->target_options & TOPT_FLAVOUR_V7MF) &&
+	           (reg < (sizeof(regnum_cortex_m) +
+	                   sizeof(regnum_cortex_mf) / 4))) {
+		return regnum_cortex_mf[reg - sizeof(regnum_cortex_m)/4];
+	} else {
+		return -1;
+	}
+}
+ssize_t cortexm_reg_read(target *t, int reg, void *data, size_t max)
+{
+	if (max < 4)
+		return -1;
+	uint32_t *r = data;
+	target_mem_write32(t, CORTEXM_DCRSR, dcrsr_regnum(t, reg));
+	*r = target_mem_read32(t, CORTEXM_DCRDR);
+	return 4;
+}
+
+ssize_t cortexm_reg_write(target *t, int reg, const void *data, size_t max)
+{
+	if (max < 4)
+		return -1;
+	const uint32_t *r = data;
+	target_mem_write32(t, CORTEXM_DCRDR, *r);
+	target_mem_write32(t, CORTEXM_DCRSR, CORTEXM_DCRSR_REGWnR |
+	                                     dcrsr_regnum(t, reg));
+	return 4;
 }
 
 static uint32_t cortexm_pc_read(target *t)

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -322,8 +322,26 @@ ssize_t target_reg_write(target *t, int reg, const void *data, size_t size)
 	return t->reg_write(t, reg, data, size);
 }
 
-void target_regs_read(target *t, void *data) { t->regs_read(t, data); }
-void target_regs_write(target *t, const void *data) { t->regs_write(t, data); }
+void target_regs_read(target *t, void *data)
+{
+	if (t->regs_read) {
+		t->regs_read(t, data);
+		return;
+	}
+	for (size_t x = 0, i = 0; x < t->regs_size; ) {
+		x += t->reg_read(t, i++, data + x, t->regs_size - x);
+	}
+}
+void target_regs_write(target *t, const void *data)
+{
+	if (t->regs_write) {
+		t->regs_write(t, data);
+		return;
+	}
+	for (size_t x = 0, i = 0; x < t->regs_size; ) {
+		x += t->reg_write(t, i++, data + x, t->regs_size - x);
+	}
+}
 
 /* Halt/resume functions */
 void target_reset(target *t) { t->reset(t); }

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -312,6 +312,16 @@ int target_mem_write(target *t, target_addr dest, const void *src, size_t len)
 }
 
 /* Register access functions */
+ssize_t target_reg_read(target *t, int reg, void *data, size_t max)
+{
+	return t->reg_read(t, reg, data, max);
+}
+
+ssize_t target_reg_write(target *t, int reg, const void *data, size_t size)
+{
+	return t->reg_write(t, reg, data, size);
+}
+
 void target_regs_read(target *t, void *data) { t->regs_read(t, data); }
 void target_regs_write(target *t, const void *data) { t->regs_write(t, data); }
 

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -96,6 +96,8 @@ struct target_s {
 	const char *tdesc;
 	void (*regs_read)(target *t, void *data);
 	void (*regs_write)(target *t, const void *data);
+	ssize_t (*reg_read)(target *t, int reg, void *data, size_t max);
+	ssize_t (*reg_write)(target *t, int reg, const void *data, size_t size);
 
 	/* Halt/resume functions */
 	void (*reset)(target *t);


### PR DESCRIPTION
- Add new target methods to access single registers
- Add GDB packets support for `p` and `P` packets
- Implement new methods in Cortex-M and Cortex-A drivers