### PR TITLE
Added after successful probe the STM32 debug bits are set

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -90,6 +90,11 @@ static int stm32f1_flash_write(struct target_flash *f,
 #define DBGMCU_IDCODE	0xE0042000
 #define DBGMCU_IDCODE_F0	0x40015800
 
+#define DBGMCU_CR		0xE0042004
+#define DBG_STANDBY		(1 << 0)
+#define DBG_STOP		(1 << 1)
+#define DBG_SLEEP		(1 << 2)
+
 #define FLASHSIZE     0x1FFFF7E0
 #define FLASHSIZE_F0  0x1FFFF7CC
 
@@ -127,6 +132,7 @@ bool stm32f1_probe(target *t)
 		target_add_ram(t, 0x20000000, 0x5000);
 		stm32f1_add_flash(t, 0x8000000, 0x20000, 0x400);
 		target_add_commands(t, stm32f1_cmd_list, "STM32 LD/MD");
+		target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 		return true;
 	case 0x414:	 /* High density */
 	case 0x418:  /* Connectivity Line */
@@ -135,6 +141,7 @@ bool stm32f1_probe(target *t)
 		target_add_ram(t, 0x20000000, 0x10000);
 		stm32f1_add_flash(t, 0x8000000, 0x80000, 0x800);
 		target_add_commands(t, stm32f1_cmd_list, "STM32 HD/CL");
+		target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 		return true;
 	case 0x422:  /* STM32F30x */
 	case 0x432:  /* STM32F37x */
@@ -145,6 +152,7 @@ bool stm32f1_probe(target *t)
 		target_add_ram(t, 0x20000000, 0x10000);
 		stm32f1_add_flash(t, 0x8000000, 0x80000, 0x800);
 		target_add_commands(t, stm32f1_cmd_list, "STM32F3");
+		target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 		return true;
 	}
 
@@ -175,6 +183,7 @@ bool stm32f1_probe(target *t)
 	target_add_ram(t, 0x20000000, 0x5000);
 	stm32f1_add_flash(t, 0x8000000, flash_size, block_size);
 	target_add_commands(t, stm32f1_cmd_list, "STM32F0");
+	target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 	return true;
 }
 

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -144,6 +144,11 @@
 #define STM32L1_NVM_OPTR_BOR_LEV_M   (0xf)
 #define STM32L1_NVM_OPTR_SPRMOD      (1<<8)
 
+#define DBGMCU_CR		0xE0042004
+#define DBG_STANDBY		(1 << 0)
+#define DBG_STOP		(1 << 1)
+#define DBG_SLEEP		(1 << 2)
+
 static int stm32lx_nvm_prog_erase(struct target_flash* f,
                                   target_addr addr, size_t len);
 static int stm32lx_nvm_prog_write(struct target_flash* f,
@@ -276,6 +281,7 @@ bool stm32l0_probe(target* t)
 		stm32l_add_flash(t, 0x8000000, 0x80000, 0x100);
 		//stm32l_add_eeprom(t, 0x8080000, 0x4000);
 		target_add_commands(t, stm32lx_cmd_list, "STM32L1x");
+		target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 		return true;
 	}
 
@@ -293,6 +299,7 @@ bool stm32l0_probe(target* t)
 		stm32l_add_flash(t, 0x8020000, 0x10000, 0x80);
 		stm32l_add_eeprom(t, 0x8080000, 0x1800);
 		target_add_commands(t, stm32lx_cmd_list, "STM32L0x");
+		target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 		return true;
 	}
 

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -112,6 +112,11 @@ static const char stm32l4_driver_str[] = "STM32L4xx";
 #define DBGMCU_IDCODE	0xE0042000
 #define FLASH_SIZE_REG  0x1FFF75E0
 
+#define DBGMCU_CR		0xE0042004
+#define DBG_STANDBY		(1 << 0)
+#define DBG_STOP		(1 << 1)
+#define DBG_SLEEP		(1 << 2)
+
 /* This routine is uses double word access.*/
 static const uint16_t stm32l4_flash_write_stub[] = {
 #include "flashstub/stm32l4.stub"
@@ -169,6 +174,7 @@ bool stm32l4_probe(target *t)
 			bank1_start =  0x08000000 + (size << 9);
 		stm32l4_add_flash(t, 0x08000000, size << 10, PAGE_SIZE, bank1_start);
 		target_add_commands(t, stm32l4_cmd_list, "STM32L4 Dual bank");
+		target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 		return true;
 	case 0x462: /* L45x L46x / RM0394  */
 	case 0x435: /* L43x L44x / RM0394  */
@@ -184,6 +190,7 @@ bool stm32l4_probe(target *t)
 		options =  target_mem_read32(t, FLASH_OPTR);
 		stm32l4_add_flash(t, 0x08000000, size << 10, PAGE_SIZE, bank1_start);
 		target_add_commands(t, stm32l4_cmd_list, "STM32L4");
+		target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 		return true;
 	}
 	return false;


### PR DESCRIPTION
This makes it possible to debug systems using WFI instructions for
example.

It was being done in the F4 target, but not the rest.
I sadly do not have HW to test it all.