### PR TITLE
platforms/stm32: Ignore noise errors on USBUART

### DIFF
--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -217,7 +217,7 @@ void USBUSART_ISR(void)
 {
 	uint32_t err = USART_SR(USBUSART);
 	char c = usart_recv(USBUSART);
-	if (err & (USART_SR_ORE | USART_SR_FE))
+	if (err & (USART_SR_ORE | USART_SR_FE | USART_SR_NE))
 		return;
 
 	/* Turn on LED */


### PR DESCRIPTION
USBUART RX signal on the native BMP (v2.1c) catches noise when the target is under reset (or being flashed). This PR improves the reception a little by ignoring noise errors.

Before (flash followed by three resets):

```
������"����8����@��}}��G"p`GuV%t7G "Hello World!
�Hello World!
�Hello World!
�Hello World!
```

After (flash followed by three resets):

```
������������Hello World!
Hello World!
Hello World!
Hello World!
```

