### PR TITLE
Speed up gpio swd

### DIFF
--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -43,6 +43,7 @@ static void swdptap_turnaround(uint8_t dir)
 	if(dir)
 		SWDIO_MODE_FLOAT();
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
 	gpio_clear(SWCLK_PORT, SWCLK_PIN);
 	if(!dir)
 		SWDIO_MODE_DRIVE();
@@ -56,6 +57,7 @@ bool swdptap_bit_in(void)
 
 	ret = gpio_get(SWDIO_PORT, SWDIO_PIN);
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
 	gpio_clear(SWCLK_PORT, SWCLK_PIN);
 
 #ifdef DEBUG_SWD_BITS
@@ -63,6 +65,64 @@ bool swdptap_bit_in(void)
 #endif
 
 	return ret != 0;
+}
+
+uint32_t
+swdptap_seq_in(int ticks)
+{
+	uint32_t index = 1;
+	uint32_t ret = 0;
+	int len = ticks;
+
+	swdptap_turnaround(1);
+	while (len--) {
+		int res;
+		res = gpio_get(SWDIO_PORT, SWDIO_PIN);
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+		if (res)
+			ret |= index;
+		index <<= 1;
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	}
+
+#ifdef DEBUG_SWD_BITS
+	for (int i = 0; i < len; i++)
+		DEBUG("%d", (ret & (1 << i)) ? 1 : 0);
+#endif
+	return ret;
+}
+
+bool
+swdptap_seq_in_parity(uint32_t *ret, int ticks)
+{
+	uint32_t index = 1;
+	uint8_t parity = 0;
+	uint32_t res = 0;
+	bool bit;
+	int len = ticks;
+
+	swdptap_turnaround(1);
+	while (len--) {
+		bit = gpio_get(SWDIO_PORT, SWDIO_PIN);
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+		if (bit) {
+			res |= index;
+			parity ^= 1;
+		}
+		index <<= 1;
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	}
+	bit = gpio_get(SWDIO_PORT, SWDIO_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	if (bit)
+		parity ^= 1;
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+#ifdef DEBUG_SWD_BITS
+	for (int i = 0; i < len; i++)
+		DEBUG("%d", (res & (1 << i)) ? 1 : 0);
+#endif
+	*ret = res;
+	return parity;
 }
 
 void swdptap_bit_out(bool val)
@@ -75,6 +135,48 @@ void swdptap_bit_out(bool val)
 
 	gpio_set_val(SWDIO_PORT, SWDIO_PIN, val);
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
 	gpio_clear(SWCLK_PORT, SWCLK_PIN);
 }
+void
+swdptap_seq_out(uint32_t MS, int ticks)
+{
+	int data = MS & 1;
+#ifdef DEBUG_SWD_BITS
+	for (int i = 0; i < ticks; i++)
+		DEBUG("%d", (MS & (1 << i)) ? 1 : 0);
+#endif
+	swdptap_turnaround(0);
+	while (ticks--) {
+		gpio_set_val(SWDIO_PORT, SWDIO_PIN, data);
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+		MS >>= 1;
+		data = MS & 1;
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	}
+}
 
+void
+swdptap_seq_out_parity(uint32_t MS, int ticks)
+{
+	uint8_t parity = 0;
+	int data = MS & 1;
+#ifdef DEBUG_SWD_BITS
+	for (int i = 0; i < ticks; i++)
+		DEBUG("%d", (MS & (1 << i)) ? 1 : 0);
+#endif
+	swdptap_turnaround(0);
+
+	while (ticks--) {
+		gpio_set_val(SWDIO_PORT, SWDIO_PIN, data);
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+		parity ^= MS;
+		MS >>= 1;
+		data = MS & 1;
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	}
+	gpio_set_val(SWDIO_PORT, SWDIO_PIN, parity & 1);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+}

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -52,12 +52,12 @@ int adiv5_swdp_scan(void)
 	swdptap_init();
 
 	/* Switch from JTAG to SWD mode */
-	swdptap_seq_out(0xFFFF, 16);
-	for(int i = 0; i < 50; i++)
-		swdptap_bit_out(1);
+	swdptap_seq_out(0xFFFFFFFF, 16);
+	swdptap_seq_out(0xFFFFFFFF, 32);
+	swdptap_seq_out(0xFFFFFFFF, 18);
 	swdptap_seq_out(0xE79E, 16); /* 0b0111100111100111 */
-	for(int i = 0; i < 50; i++)
-		swdptap_bit_out(1);
+	swdptap_seq_out(0xFFFFFFFF, 32);
+	swdptap_seq_out(0xFFFFFFFF, 18);
 	swdptap_seq_out(0, 16);
 
 	/* Read the SW-DP IDCODE register to syncronise */


### PR DESCRIPTION
- "unroll" complex swd function, inline access.
- Use swdptap_seq_out in  adiv5_swdp_scan()

Load to RAM on STM32L476 got from 46  to 84 kB/sec.