### PR TITLE
Support for the STM32H743I-EVAL

### DIFF
--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -4,6 +4,8 @@
  * Copyright (C) 2011  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
  *
+ * Copyright (c) 2018, Elias Oenal <bmp@eliasoenal.com>
+ * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -22,6 +24,10 @@
 
 #include "general.h"
 #include "swdptap.h"
+
+#ifndef INLINE_GPIO
+#define gpio_clock(port, pin) gpio_set(port, pin); gpio_clear(port,pin)
+#endif
 
 int swdptap_init(void)
 {
@@ -42,8 +48,7 @@ static void swdptap_turnaround(uint8_t dir)
 
 	if(dir)
 		SWDIO_MODE_FLOAT();
-	gpio_set(SWCLK_PORT, SWCLK_PIN);
-	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	gpio_clock(SWCLK_PORT, SWCLK_PIN);
 	if(!dir)
 		SWDIO_MODE_DRIVE();
 }
@@ -55,8 +60,7 @@ bool swdptap_bit_in(void)
 	swdptap_turnaround(1);
 
 	ret = gpio_get(SWDIO_PORT, SWDIO_PIN);
-	gpio_set(SWCLK_PORT, SWCLK_PIN);
-	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	gpio_clock(SWCLK_PORT, SWCLK_PIN);
 
 #ifdef DEBUG_SWD_BITS
 	DEBUG("%d", ret?1:0);
@@ -74,7 +78,6 @@ void swdptap_bit_out(bool val)
 	swdptap_turnaround(0);
 
 	gpio_set_val(SWDIO_PORT, SWDIO_PIN, val);
-	gpio_set(SWCLK_PORT, SWCLK_PIN);
-	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	gpio_clock(SWCLK_PORT, SWCLK_PIN);
 }
 

--- a/src/platforms/stm32/delay.h
+++ b/src/platforms/stm32/delay.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2010 Perry Hung.
+ * Copyright (c) 2011 LeafLabs, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+#ifndef DELAY_H
+#define DELAY_H
+
+#include <stdint.h>
+
+#ifndef STM32F4
+#define STM32_DELAY_US_MULT 12 /* When running from flash. */
+#else
+#define STM32_DELAY_US_MULT 56 /* When running from flash. */
+#endif
+
+/**
+ * @brief Delay the given number of microseconds.
+ *
+ * @param us Number of microseconds to delay.
+ */
+static inline void udelay(uint32_t us) {
+    us *= STM32_DELAY_US_MULT;
+    asm volatile("   mov r0, %[us]          \n\t"
+                 "1: subs r0, #1            \n\t"
+                 "   bhi 1b                 \n\t"
+                 :
+                 : [us] "r" (us)
+                 : "r0");
+}
+
+#endif

--- a/src/platforms/stm32/gpio.h
+++ b/src/platforms/stm32/gpio.h
@@ -68,6 +68,7 @@ static inline void gpio_clock(uint32_t gpioport, uint16_t gpios)
 	_gpio_set(gpioport, gpios);
 	udelay(1);
 	_gpio_clear(gpioport, gpios);
+	udelay(1);
 }
 
 static inline uint16_t _gpio_get(uint32_t gpioport, uint16_t gpios)

--- a/src/platforms/stm32/gpio.h
+++ b/src/platforms/stm32/gpio.h
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2015  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ * 
+ * Copyright (c) 2018, Elias Oenal <bmp@eliasoenal.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +23,7 @@
 #define __GPIO_H
 
 #include <libopencm3/cm3/common.h>
+#include "delay.h"
 
 #ifndef STM32F4
 #	include <libopencm3/stm32/f1/memorymap.h>
@@ -59,6 +62,13 @@ static inline void _gpio_clear(uint32_t gpioport, uint16_t gpios)
 #endif
 }
 #define gpio_clear _gpio_clear
+
+static inline void gpio_clock(uint32_t gpioport, uint16_t gpios)
+{
+	_gpio_set(gpioport, gpios);
+	udelay(1);
+	_gpio_clear(gpioport, gpios);
+}
 
 static inline uint16_t _gpio_get(uint32_t gpioport, uint16_t gpios)
 {


### PR DESCRIPTION
I noticed that whenever I built the BMP firmware with optimisations, I couldn't communicate with my development board anymore. I narrowed it down to the bitbang swdp implementation and at first adding 1µs of delay solved the issue. Then I tried a second board, for which I had to up the delay to 2µs. I know that my workaround seriously impacts performance, (Transfer rate: 17 KB/sec, 967 bytes/write.) but at least it allows programming. Are there any better ways to fix this?

![img_4223](https://user-images.githubusercontent.com/1494995/35734706-ff7506b8-085c-11e8-999e-bac3ce03f810.jpg)
