### PR TITLE
hexprog.hex fails due to divide-by-zero

### DIFF
--- a/scripts/gdb.py
+++ b/scripts/gdb.py
@@ -241,7 +241,7 @@ class Target:
 			block = 0
 			for i in range(len(self.blocks)):
 				block += 1
-				if callable(progress_cb):
+				if callable(progress_cb) and totalblocks > 0:
 					progress_cb(block*100/totalblocks)
 
 				# Erase the block


### PR DESCRIPTION
I tried flashing an STM32L0 with hexprog.py:
`sudo python hexprog.py -s main.hex`

But it fails during programming...
![image](https://user-images.githubusercontent.com/2604419/37257644-572fbb92-253a-11e8-8e20-5e81dc1869f7.png)

Running with the -r flag didn't help and I know for certain that there is no flash read protection on my DUT.

I looked around a bit and noticed that, for whatever reason, the first memory section it tries to flash has totalblocks=0 when evaluating flash_commit()--causing a divide-by-zero error. The fix is self-explanatory.
