### PR TITLE
Fixes fall through GCC V7 errors.

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -155,7 +155,8 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 			}
 		case 's':	/* 's [addr]': Single step [start at addr] */
 			single_step = true;
-			// Fall through to resume target
+			/* Fall through */
+			/* to resume target */
 		case 'c':	/* 'c [addr]': Continue [at addr] */
 			if(!cur_target) {
 				gdb_putpacketz("X1D");
@@ -165,7 +166,8 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 			target_halt_resume(cur_target, single_step);
 			SET_RUN_STATE(1);
 			single_step = false;
-			// Fall through to wait for target halt
+			/* Fall through */
+			/* to wait for target halt */
 		case '?': {	/* '?': Request reason for target halt */
 			/* This packet isn't documented as being mandatory,
 			 * but GDB doesn't work without it. */

--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -441,6 +441,7 @@ static int cdcacm_control_request(usbd_device *dev,
 		switch(req->wIndex) {
 		case 2:
 			usbuart_set_line_coding((struct usb_cdc_line_coding*)*buf);
+			/* Falls through. */
 		case 0:
 			return 1; /* Ignore on GDB Port */
 		default:
@@ -458,6 +459,7 @@ static int cdcacm_control_request(usbd_device *dev,
 
 			return 1;
 		}
+		/* Falls through. */
 	case DFU_DETACH:
 		if(req->wIndex == DFU_IF_NO) {
 			*complete = dfu_detach_complete;

--- a/src/platforms/stm32/dfucore.c
+++ b/src/platforms/stm32/dfucore.c
@@ -174,6 +174,7 @@ usbdfu_getstatus_complete(usbd_device *dev, struct usb_setup_data *req)
 			switch(prog.buf[0]) {
 			case CMD_ERASE:
 				dfu_check_and_do_sector_erase(addr);
+				/* Falls through. */
 			case CMD_SETADDR:
 				prog.addr = addr;
 			}

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -161,7 +161,8 @@ bool stm32f4_probe(target *t)
 		stm32f4_add_flash(t, 0x8100000, 0x10000, 0x4000, 12);
 		stm32f4_add_flash(t, 0x8110000, 0x10000, 0x10000, 16);
 		stm32f4_add_flash(t, 0x8120000, 0xE0000, 0x20000, 17);
-		/* Fall through for stuff common to F40x/F41x */
+		/* Fall through */
+		/* for stuff common to F40x/F41x */
 	case 0x411: /* F205 */
 	case 0x413: /* F405 */
 	case 0x421: /* F446 */


### PR DESCRIPTION
Note: This PR is specifically for the V1.6 branch of the code.

GCC V7 considers fallthrough that is not marked an error. It also
expects the markers to be formatted a specific way. This patch fixes
those issues. For more information refer to the -Wimplicit-fallthrough
redhat article:
https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/