### PR TITLE
Update to split 'special' register into its sane parts

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -125,7 +125,10 @@ static const char tdesc_cortex_m[] =
 	"    <reg name=\"xpsr\" bitsize=\"32\"/>"
 	"    <reg name=\"msp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
 	"    <reg name=\"psp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
-	"    <reg name=\"special\" bitsize=\"32\" save-restore=\"no\"/>"
+	"    <reg name=\"PRIMASK\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"BASEPRI\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"FAULTMASK\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"Control\" bitsize=\"8\" save-restore=\"no\"/>"
 	"  </feature>"
 	"</target>";
 
@@ -154,7 +157,10 @@ static const char tdesc_cortex_mf[] =
 	"    <reg name=\"xpsr\" bitsize=\"32\"/>"
 	"    <reg name=\"msp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
 	"    <reg name=\"psp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
-	"    <reg name=\"special\" bitsize=\"32\" save-restore=\"no\"/>"
+	"    <reg name=\"PRIMASK\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"BASEPRI\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"FAULTMASK\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"Control\" bitsize=\"8\" save-restore=\"no\"/>"
 	"  </feature>"
 	"  <feature name=\"org.gnu.gdb.arm.vfp\">"
 	"    <reg name=\"fpscr\" bitsize=\"32\"/>"


### PR DESCRIPTION
Hi, I took the changes @mubes did and expanded a bit, to make it a formal PR.
This will split the `special` register into its sane parts `BASEPRI`, `PRIMASK`, `FAULTMASK`, `CONTROL`.

BR Emil