### PR TITLE
Fix flashing hanging or not working

### DIFF
--- a/src/platforms/stlink/Readme
+++ b/src/platforms/stlink/Readme
@@ -9,3 +9,9 @@ ID Pins PC13/14 unconnected       PC 13 pulled low
 LED STLINK      PA8, active High  PA9, Dual Led
 MCO Out         NA                PA8
 RESET(Target)   T_JRST(PB1)       NRST (PB0)
+
+On the NucleoXXXP boards, e.g. NUCLEO-L4R5ZI (144 pin) or
+NUCLEO-L452RE-P (64 pins), by default nRst is not connected. To reach the
+target nRST pin with the "mon connect_srst enable" option, the right NRST
+jumper must be placed. On Nucleo144-P boards it is JP3, on NUCLEO64-P
+boards it is JP4.

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -90,10 +90,21 @@ void platform_init(void)
 
 void platform_srst_set_val(bool assert)
 {
-	if (assert)
-		gpio_clear(SRST_PORT, srst_pin);
-	else
-		gpio_set(SRST_PORT, srst_pin);
+	uint32_t crl = GPIOB_CRL;
+	uint32_t shift = (srst_pin == GPIO0) ? 0 : 4;
+	uint32_t mask = 0xf << shift;
+	crl &= ~mask;
+	if (assert) {
+		/* Set SRST as Open-Drain, 50 Mhz, low.*/
+		GPIOB_BRR = srst_pin;
+		GPIOB_CRL = crl | (7 << shift);
+	} else {
+		/* Set SRST as input, pull-up.
+		 * SRST might be unconnected, e.g on Nucleo-P!*/
+		GPIOB_CRL = crl | (8 << shift);
+		GPIOB_BSRR = srst_pin;
+	}
+	while (gpio_get(SRST_PORT, srst_pin) == assert) {};
 }
 
 bool platform_srst_get_val()

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -401,7 +401,10 @@ void cortexm_detach(target *t)
 	/* Clear any stale watchpoints */
 	for(i = 0; i < priv->hw_watchpoint_max; i++)
 		target_mem_write32(t, CORTEXM_DWT_FUNC(i), 0);
-
+	/* Release exception catch .*/
+	target_mem_write32(t, CORTEXM_DEMCR, 0);
+	/* Continue running target where stopped.*/
+	cortexm_halt_resume(t, 0);
 	/* Disable debug */
 	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY);
 }

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -296,6 +296,16 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		target_check_error(t);
 	}
 
+	bool connect_srst = platform_srst_get_val();
+	/* Enable debug access for probing.*/
+	target_halt_request(t);
+	if (connect_srst) {
+		/* Connect_srst is active. Request halt on reset to inhibit
+		   start of the target CPU when releasing nRST.*/
+		target_mem_write32(t, CORTEXM_DEMCR, priv->demcr);
+	}
+	/* Always wait until nRST is released.*/
+	platform_srst_set_val(false);
 #define PROBE(x) \
 	do { if ((x)(t)) return true; else target_check_error(t); } while (0)
 
@@ -315,7 +325,12 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	PROBE(kinetis_probe);
 	PROBE(efm32_probe);
 #undef PROBE
-
+	if (connect_srst) {
+		platform_srst_set_val(true);
+		target_mem_write32(t, CORTEXM_DEMCR, 0);
+	}
+	/* Disable Debug access.*/
+	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY);
 	return true;
 }
 


### PR DESCRIPTION
If construction of the memory map needs to read target CPU register, the memory map was invalid on first attach after power on or always when connect_srst was enabled. This resulted in no real write to flash while the load command obvious succeeded, also at much higher speed. The load commands hanged on another board where nRST had a slow rise after SRST de-asserted and flashing started with the MCU still in reset.