### PR TITLE
nrf51: Add nRF51802 device id.

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -130,6 +130,7 @@ bool nrf51_probe(target *t)
 	case 0x007A: /* nRF51422 (rev 3) CEAA C0 */
 	case 0x008F: /* nRF51822 (rev 3) QFAA H1 See https://devzone.nordicsemi.com/question/97769/can-someone-conform-the-config-id-code-for-the-nrf51822qfaah1/ */
 	case 0x00D1: /* nRF51822 (rev 3) QFAA H2 */		
+	case 0x0114: /* nRF51802 (rev ?) QFAA A1 */
 		t->driver = "Nordic nRF51";
 		target_add_ram(t, 0x20000000, 0x4000);
 		nrf51_add_flash(t, 0x00000000, 0x40000, NRF51_PAGE_SIZE);


### PR DESCRIPTION
This adds the (mysterious) nRF51802.
@NordicSemiconductor is rather cagey about this chip so I can't find any docs to point to, but it seems to be mostly the same as the nRF51822. I retrieved the device ID, RAM size & flash size from the FICR. It's tested and working without any issues so far.

For future reference the chip markings are:

    N51802
    QFAAA1
    1720IW