### PR TITLE
Split probe and attach

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -354,7 +354,9 @@ handle_q_packet(char *packet, int len)
 			gdb_putpacketz("E01");
 			return;
 		}
-		handle_q_string_reply(target_mem_map(cur_target), packet + 23);
+		char buf[1024];
+		target_mem_map(cur_target, buf, sizeof(buf)); /* Fixme: Check size!*/
+		handle_q_string_reply(buf, packet + 23);
 
 	} else if (strncmp (packet, "qXfer:features:read:target.xml:", 31) == 0) {
 		/* Read target description */

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -45,7 +45,7 @@ bool target_attached(target *t);
 const char *target_driver_name(target *t);
 
 /* Memory access functions */
-const char *target_mem_map(target *t);
+bool target_mem_map(target *t, char *buf, size_t len);
 int target_mem_read(target *t, void *dest, target_addr src, size_t len);
 int target_mem_write(target *t, target_addr dest, const void *src, size_t len);
 /* Flash memory access functions */

--- a/src/platforms/stlink/Readme
+++ b/src/platforms/stlink/Readme
@@ -9,3 +9,9 @@ ID Pins PC13/14 unconnected       PC 13 pulled low
 LED STLINK      PA8, active High  PA9, Dual Led
 MCO Out         NA                PA8
 RESET(Target)   T_JRST(PB1)       NRST (PB0)
+
+On the NucleoXXXP boards, e.g. NUCLEO-L4R5ZI (144 pin) or
+NUCLEO-L452RE-P (64 pins), by default nRst is not connected. To reach the
+target nRST pin with the "mon connect_srst enable" option, the right NRST
+jumper must be placed. On Nucleo144-P boards it is JP3, on NUCLEO64-P
+boards it is JP4.

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -90,10 +90,21 @@ void platform_init(void)
 
 void platform_srst_set_val(bool assert)
 {
-	if (assert)
-		gpio_clear(SRST_PORT, srst_pin);
-	else
-		gpio_set(SRST_PORT, srst_pin);
+	uint32_t crl = GPIOB_CRL;
+	uint32_t shift = (srst_pin == GPIO0) ? 0 : 4;
+	uint32_t mask = 0xf << shift;
+	crl &= ~mask;
+	if (assert) {
+		/* Set SRST as Open-Drain, 50 Mhz, low.*/
+		GPIOB_BRR = srst_pin;
+		GPIOB_CRL = crl | (7 << shift);
+	} else {
+		/* Set SRST as input, pull-up.
+		 * SRST might be unconnected, e.g on Nucleo-P!*/
+		GPIOB_CRL = crl | (8 << shift);
+		GPIOB_BSRR = srst_pin;
+	}
+	while (gpio_get(SRST_PORT, srst_pin) == assert) {};
 }
 
 bool platform_srst_get_val()

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -69,7 +69,7 @@
 #define LED_UART	GPIO14
 
 #define PLATFORM_HAS_TRACESWO	1
-#define NUM_TRACE_PACKETS		(192)		/* This is an 12K buffer */
+#define NUM_TRACE_PACKETS		(128)		/* This is an 8K buffer */
 
 #define TMS_SET_MODE() \
 	gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_50_MHZ, \

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -153,26 +153,30 @@ bool stm32f1_probe(target *t)
 	switch(t->idcode) {
 	case 0x444:  /* STM32F03 RM0091 Rev.7, STM32F030x[4|6] RM0360 Rev. 4*/
 		t->driver = "STM32F03";
+		flash_size = 0x8000;
 		break;
 	case 0x445:  /* STM32F04 RM0091 Rev.7, STM32F070x6 RM0360 Rev. 4*/
 		t->driver = "STM32F04/F070x6";
+		flash_size = 0x8000;
 		break;
 	case 0x440:  /* STM32F05 RM0091 Rev.7, STM32F030x8 RM0360 Rev. 4*/
 		t->driver = "STM32F05/F030x8";
+		flash_size = 0x10000;
 		break;
 	case 0x448:  /* STM32F07 RM0091 Rev.7, STM32F070xB RM0360 Rev. 4*/
 		t->driver = "STM32F07";
+		flash_size = 0x20000;
 		block_size = 0x800;
 		break;
 	case 0x442:  /* STM32F09 RM0091 Rev.7, STM32F030xC RM0360 Rev. 4*/
 		t->driver = "STM32F09/F030xC";
+		flash_size = 0x40000;
 		block_size = 0x800;
 		break;
 	default:     /* NONE */
 		return false;
 	}
 
-	flash_size = (target_mem_read32(t, FLASHSIZE_F0) & 0xffff) *0x400;
 	target_add_ram(t, 0x20000000, 0x5000);
 	stm32f1_add_flash(t, 0x8000000, flash_size, block_size);
 	target_add_commands(t, stm32f1_cmd_list, "STM32F0");

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -197,6 +197,7 @@ bool stm32f4_probe(target *t)
 		t->idcode = idcode;
 		t->driver = "STM32F4";
 		t->attach = stm32f4_attach;
+		target_add_commands(t, stm32f4_cmd_list, "stm32f4");
 		return true;
 	default:
 		return false;
@@ -273,8 +274,8 @@ static bool stm32f4_attach(target *t)
 	}
 	target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 	t->driver = designator;
-	target_add_commands(t, stm32f4_cmd_list, designator);
 	bool use_dual_bank = false;
+	target_mem_map_free(t);
 	uint32_t flashsize = target_mem_read32(t, flashsize_base) & 0xffff;
 	if (is_f7) {
 		target_add_ram(t, 0x00000000, 0x4000);  /* 16 k ITCM Ram */

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -48,7 +48,7 @@ const struct command_s stm32f4_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-
+static bool stm32f4_attach(target *t);
 static int stm32f4_flash_erase(struct target_flash *f, target_addr addr,
 							   size_t len);
 static int stm32f4_flash_write(struct target_flash *f,
@@ -170,16 +170,7 @@ static void stm32f4_add_flash(target *t,
 
 bool stm32f4_probe(target *t)
 {
-	uint32_t idcode;
-	const char* designator = NULL;
-	bool dual_bank = false;
-	bool has_ccmram = false;
-	bool is_f7  = false;
-	bool large_sectors = false;
-	uint32_t flashsize_base = F4_FLASHSIZE;
-
-	idcode = target_mem_read32(t, DBGMCU_IDCODE);
-	idcode &= 0xFFF;
+	uint32_t idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xFFF;
 
 	if (idcode == ID_STM32F20X) {
 		/* F405 revision A have a wrong IDCODE, use ARM_CPUID to make the
@@ -190,6 +181,41 @@ bool stm32f4_probe(target *t)
 			idcode = ID_STM32F40X;
 	}
 	switch(idcode) {
+	case ID_STM32F40X:
+	case ID_STM32F42X: /* 427/437 */
+	case ID_STM32F46X: /* 469/479 */
+	case ID_STM32F20X: /* F205 */
+	case ID_STM32F446: /* F446 */
+	case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
+	case ID_STM32F411: /* F411     RM0383 Rev.4 */
+	case ID_STM32F412: /* F412     RM0402 Rev.4, 256 kB Ram */
+	case ID_STM32F401E: /* F401 D/E RM0368 Rev.3 */
+	case ID_STM32F413: /* F413     RM0430 Rev.2, 320 kB Ram, 1.5 MB flash. */
+	case ID_STM32F74X: /* F74x RM0385 Rev.4 */
+	case ID_STM32F76X: /* F76x F77x RM0410 */
+	case ID_STM32F72X: /* F72x F73x RM0431 */
+		t->idcode = idcode;
+		t->driver = "STM32F4";
+		t->attach = stm32f4_attach;
+		return true;
+	default:
+		return false;
+	}
+}
+
+static bool stm32f4_attach(target *t)
+{
+	const char* designator = NULL;
+	bool dual_bank = false;
+	bool has_ccmram = false;
+	bool is_f7  = false;
+	bool large_sectors = false;
+	uint32_t flashsize_base = F4_FLASHSIZE;
+
+	if (!cortexm_attach(t))
+		return false;
+
+	switch(t->idcode) {
 	case ID_STM32F40X:
 		designator = "STM32F40x";
 		has_ccmram = true;
@@ -248,7 +274,6 @@ bool stm32f4_probe(target *t)
 	target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 	t->driver = designator;
 	target_add_commands(t, stm32f4_cmd_list, designator);
-	t->idcode = idcode;
 	bool use_dual_bank = false;
 	uint32_t flashsize = target_mem_read32(t, flashsize_base) & 0xffff;
 	if (is_f7) {

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -124,6 +124,7 @@ struct target_s {
 	void (*priv_free)(void *);
 };
 
+void target_mem_map_free(target *t);
 void target_add_commands(target *t, const struct command_s *cmds, const char *name);
 void target_add_ram(target *t, target_addr start, uint32_t len);
 void target_add_flash(target *t, struct target_flash *f);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -109,8 +109,6 @@ struct target_s {
 	unsigned target_options;
 	uint32_t idcode;
 
-	/* Target memory map */
-	char *dyn_mem_map;
 	struct target_ram *ram;
 	struct target_flash *flash;
 


### PR DESCRIPTION
In some devices, peripheral registers are inaccessible when the device is in reset.  As a result the memory map can only be constructed at the attach stage, when the core can be halted and released from reset.

See #329 for more discussion.

This PR splits the probe and attach functions for affected STM32 devices.  The memory map is constructed during attach.

To save memory, the XML memory map is constructed on the stack.
Minor accommodating changes to the stlink platform are included.