### PR TITLE
Update maximum RAM sizes for F4 and F7 devices

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -253,7 +253,8 @@ bool stm32f4_probe(target *t)
 	uint32_t flashsize = target_mem_read32(t, flashsize_base) & 0xffff;
 	if (is_f7) {
 		target_add_ram(t, 0x00000000, 0x4000);  /* 16 k ITCM Ram */
-		target_add_ram(t, 0x20000000, 0x10000); /* 64 k DTCM Ram */
+		target_add_ram(t, 0x20000000, 0x20000); /* 128 k DTCM Ram */
+		target_add_ram(t, 0x20020000, 0x60000); /* 384 k Ram */
 		if (dual_bank) {
 			uint32_t optcr;
 			optcr = target_mem_read32(t, FLASH_OPTCR);
@@ -262,7 +263,7 @@ bool stm32f4_probe(target *t)
 	} else {
 		if (has_ccmram)
 			target_add_ram(t, 0x10000000, 0x10000); /* 64 k CCM Ram*/
-		target_add_ram(t, 0x20000000, 0x10000);     /* 64 k RAM */
+		target_add_ram(t, 0x20000000, 0x50000);     /* 320 k RAM */
 		if (dual_bank) {
 			use_dual_bank = true;
 			if (flashsize < 0x800) {


### PR DESCRIPTION
In commit c4d3712 the `target_add_ram` call for STM32F4 devices was changed from a size of 0x40000 to 0x10000, which means gdb by default will refuse to read variables that live in RAM beyond the first 64kB. This also impacts semihosting when the memory to read lives beyond the first 64kB. Setting `mem inaccessible-by-default off` in gdb resolves the issue, but is a workaround rather than a solution.

This PR updates the calls to use the maximum RAM sizes for the F4 and F7 devices.

I'm not clear if `target_add_ram` should give the _minimum_ or _maximum_ RAM sizes; specifically does this change how much is attempted to be written at once when writing flash? If so I guess these calls should somehow work out precisely how much RAM is available rather than the family min/max. This updated version doesn't seem to have problems programming flash even when using devices with less than the maximum RAM, though.