### PR TITLE
cortexm: On detach, clear Debug Exception and Monitor Control Register.

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -379,6 +379,9 @@ void cortexm_detach(target *t)
 	struct cortexm_priv *priv = t->priv;
 	unsigned i;
 
+	/* Clear halt on reset */
+	target_mem_write32(t, CORTEXM_DEMCR, 0);
+
 	/* Clear any stale breakpoints */
 	for(i = 0; i < priv->hw_breakpoint_max; i++)
 		target_mem_write32(t, CORTEXM_FPB_COMP(i), 0);


### PR DESCRIPTION
Without clearing, reset (e.g. by the reset buttom) is ignored after detach
at least on STM32. Fixes #339.