### PR TITLE
Blue Pill as separate platform

### DIFF
--- a/src/platforms/bluepill/Makefile.inc
+++ b/src/platforms/bluepill/Makefile.inc
@@ -1,0 +1,36 @@
+CROSS_COMPILE ?= arm-none-eabi-
+CC = $(CROSS_COMPILE)gcc
+OBJCOPY = $(CROSS_COMPILE)objcopy
+
+OPT_FLAGS = -Os
+CFLAGS += -mcpu=cortex-m3 -mthumb \
+	-DSTM32F1 -DDISCOVERY_STLINK -I../libopencm3/include \
+	-I platforms/stm32
+LDFLAGS_BOOT := $(LDFLAGS) --specs=nano.specs \
+	-lopencm3_stm32f1 -Wl,--defsym,_stack=0x20005000 \
+	-Wl,-T,platforms/stm32/stlink.ld -nostartfiles -lc \
+	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m3 -Wl,-gc-sections \
+	-L../libopencm3/lib
+LDFLAGS = $(LDFLAGS_BOOT)
+
+ifeq ($(ENABLE_DEBUG), 1)
+LDFLAGS += --specs=rdimon.specs
+else
+LDFLAGS += --specs=nosys.specs
+endif
+
+VPATH += platforms/stm32
+
+SRC += 	cdcacm.c	\
+	usbuart.c 	\
+	serialno.c	\
+	timing.c	\
+	timing_stm32.c	\
+	traceswoasync.c	\
+	stlink_common.c \
+
+all:	blackmagic.bin
+
+host_clean:
+	-$(Q)$(RM) blackmagic.bin
+

--- a/src/platforms/bluepill/Readme
+++ b/src/platforms/bluepill/Readme
@@ -1,0 +1,3 @@
+Modified from STLink platform to use different pins. SWDIO/TMS and SWCLK/TCK are now on PA13 and PA14, the Blue Pill's own SWD pins, allowing one to connect the debug pins straight across from the debugger to a target Blue Pill, and allowing the debugger to be used without soldering any header pins. This means the debugger device has its own SWD/JTAG hardware disabled, but setting the boot jumper to run the serial bootloader will enable it again.
+
+Finally, rather than using the DFU bootloader, blackmagic.bin is built for a base address of 0x8000000 and is meant to be flashed directly.

--- a/src/platforms/bluepill/platform.h
+++ b/src/platforms/bluepill/platform.h
@@ -1,0 +1,149 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* This file implements the platform specific functions for the STM32
+ * implementation.
+ */
+#ifndef __PLATFORM_H
+#define __PLATFORM_H
+
+#include "gpio.h"
+#include "timing.h"
+#include "timing_stm32.h"
+#include "version.h"
+
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/stm32/f1/memorymap.h>
+#include <libopencm3/usb/usbd.h>
+
+#ifdef ENABLE_DEBUG
+# define PLATFORM_HAS_DEBUG
+# define USBUART_DEBUG
+#endif
+
+#define BOARD_IDENT       "Black Magic Probe (STLINK), (Firmware " FIRMWARE_VERSION ")"
+#define BOARD_IDENT_DFU   "Black Magic (Upgrade) for STLink/Discovery, (Firmware " FIRMWARE_VERSION ")"
+#define BOARD_IDENT_UPD   "Black Magic (DFU Upgrade) for STLink/Discovery, (Firmware " FIRMWARE_VERSION ")"
+#define DFU_IDENT         "Black Magic Firmware Upgrade (STLINK)"
+#define UPD_IFACE_STRING  "@Internal Flash   /0x08000000/8*001Kg"
+
+/* Hardware definitions... */
+#define TDI_PORT	GPIOA
+#define TMS_PORT	GPIOA
+#define TCK_PORT	GPIOA
+#define TDO_PORT	GPIOA
+#define TDI_PIN		GPIO7
+#define TMS_PIN		GPIO13
+#define TCK_PIN		GPIO14
+#define TDO_PIN		GPIO6
+
+#define SWDIO_PORT 	TMS_PORT
+#define SWCLK_PORT 	TCK_PORT
+#define SWDIO_PIN	TMS_PIN
+#define SWCLK_PIN	TCK_PIN
+
+#define SRST_PORT	GPIOB
+#define SRST_PIN_V1	GPIO1
+#define SRST_PIN_V2	GPIO0
+
+#define LED_PORT	GPIOC
+/* Use PC14 for a "dummy" uart led. So we can observere at least with scope*/
+#define LED_PORT_UART	GPIOC
+#define LED_UART	GPIO14
+
+#define PLATFORM_HAS_TRACESWO	1
+#define NUM_TRACE_PACKETS		(128)		/* This is an 8K buffer */
+
+#define TMS_SET_MODE() \
+	gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_50_MHZ, \
+	              GPIO_CNF_OUTPUT_PUSHPULL, TMS_PIN);
+#define SWDIO_MODE_FLOAT() \
+	gpio_set_mode(SWDIO_PORT, GPIO_MODE_INPUT, \
+	              GPIO_CNF_INPUT_FLOAT, SWDIO_PIN);
+#define SWDIO_MODE_DRIVE() \
+	gpio_set_mode(SWDIO_PORT, GPIO_MODE_OUTPUT_50_MHZ, \
+	              GPIO_CNF_OUTPUT_PUSHPULL, SWDIO_PIN);
+
+#define UART_PIN_SETUP() \
+	gpio_set_mode(USBUSART_PORT, GPIO_MODE_OUTPUT_2_MHZ, \
+	              GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, USBUSART_TX_PIN);
+
+#define USB_DRIVER      st_usbfs_v1_usb_driver
+#define USB_IRQ	        NVIC_USB_LP_CAN_RX0_IRQ
+#define USB_ISR	        usb_lp_can_rx0_isr
+/* Interrupt priorities.  Low numbers are high priority.
+ * For now USART2 preempts USB which may spin while buffer is drained.
+ */
+#define IRQ_PRI_USB		(2 << 4)
+#define IRQ_PRI_USBUSART	(1 << 4)
+#define IRQ_PRI_USBUSART_TIM	(3 << 4)
+#define IRQ_PRI_USB_VBUS	(14 << 4)
+#define IRQ_PRI_SWO_DMA			(1 << 4)
+
+#define USBUSART USART2
+#define USBUSART_CR1 USART2_CR1
+#define USBUSART_IRQ NVIC_USART2_IRQ
+#define USBUSART_CLK RCC_USART2
+#define USBUSART_PORT GPIOA
+#define USBUSART_TX_PIN GPIO2
+#define USBUSART_ISR usart2_isr
+#define USBUSART_TIM TIM4
+#define USBUSART_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM4)
+#define USBUSART_TIM_IRQ NVIC_TIM4_IRQ
+#define USBUSART_TIM_ISR tim4_isr
+
+#ifdef ENABLE_DEBUG
+extern bool debug_bmp;
+int usbuart_debug_write(const char *buf, size_t len);
+# define DEBUG printf
+#else
+# define DEBUG(...)
+#endif
+
+/* On F103, only USART1 is on AHB2 and can reach 4.5 MBaud at 72 MHz.*/
+#define SWO_UART				USART1
+#define SWO_UART_DR				USART1_DR
+#define SWO_UART_CLK			RCC_USART1
+#define SWO_UART_PORT			GPIOA
+#define SWO_UART_RX_PIN			GPIO10
+
+/* This DMA channel is set by the USART in use */
+#define SWO_DMA_BUS				DMA1
+#define SWO_DMA_CLK				RCC_DMA1
+#define SWO_DMA_CHAN			DMA_CHANNEL5
+#define SWO_DMA_IRQ				NVIC_DMA1_CHANNEL5_IRQ
+#define SWO_DMA_ISR(x)			dma1_channel5_isr(x)
+
+extern uint16_t led_idle_run;
+#define LED_IDLE_RUN            led_idle_run
+#define SET_RUN_STATE(state)	{running_status = (state);}
+#define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, led_idle_run, state);}
+#define SET_ERROR_STATE(x)
+
+extern uint32_t detect_rev(void);
+
+/* Use newlib provided integer only stdio functions */
+#define sscanf siscanf
+#define sprintf siprintf
+#define vasprintf vasiprintf
+#define snprintf sniprintf
+
+#endif
+

--- a/src/platforms/bluepill/stlink_common.c
+++ b/src/platforms/bluepill/stlink_common.c
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2017 Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/scb.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+/* return 0 for stlink V1, 1 for stlink V2 and 2 for stlink V2.1 */
+uint32_t detect_rev(void)
+{
+	uint32_t rev;
+	int res;
+
+	while (RCC_CFGR & 0xf) /* Switch back to HSI. */
+		RCC_CFGR &= ~3;
+	rcc_periph_clock_enable(RCC_GPIOA);
+	rcc_periph_clock_enable(RCC_GPIOB);
+	rcc_periph_clock_enable(RCC_GPIOC);
+	rcc_periph_clock_enable(RCC_USB);
+	rcc_periph_reset_pulse(RST_USB);
+	rcc_periph_clock_enable(RCC_AFIO);
+	rcc_periph_clock_enable(RCC_CRC);
+	/* First, get Board revision by pulling PC13/14 up. Read
+	 *  11 for ST-Link V1, e.g. on VL Discovery, tag as rev 0
+	 *  00 for ST-Link V2, e.g. on F4 Discovery, tag as rev 1
+	 *  01 for ST-Link V2, else,                 tag as rev 1
+	 */
+	gpio_set_mode(GPIOC, GPIO_MODE_INPUT,
+				  GPIO_CNF_INPUT_PULL_UPDOWN, GPIO14 | GPIO13);
+	gpio_set(GPIOC, GPIO14 | GPIO13);
+	for (int i = 0; i < 100; i ++)
+		res = gpio_get(GPIOC, GPIO13);
+	if (res)
+		rev = 0;
+	else {
+		/* Check for V2.1 boards.
+		 * PA15/TDI is USE_RENUM, pulled with 10 k to U5V on V2.1,
+		 * Otherwise unconnected. Enable pull low. If still high.
+		 * it is V2.1.*/
+		rcc_periph_clock_enable(RCC_AFIO);
+		AFIO_MAPR |= 0x02000000; /* Release from TDI.*/
+		gpio_set_mode(GPIOA, GPIO_MODE_INPUT,
+                                 GPIO_CNF_INPUT_PULL_UPDOWN, GPIO15);
+		gpio_clear(GPIOA, GPIO15);
+		for (int i = 0; i < 100; i++)
+			res =  gpio_get(GPIOA, GPIO15);
+		if (res) {
+			rev = 2;
+			/* Pull PWR_ENn low.*/
+			gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ,
+						  GPIO_CNF_OUTPUT_OPENDRAIN, GPIO15);
+			gpio_clear(GPIOB, GPIO15);
+			/* Pull USB_RENUM low!*/
+			gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
+						  GPIO_CNF_OUTPUT_OPENDRAIN, GPIO15);
+			gpio_clear(GPIOA, GPIO15);
+		} else
+			/* Catch F4 Disco board with both resistors fitted.*/
+			rev = 1;
+		/* On Rev > 0 unconditionally activate MCO on PORTA8 with HSE! */
+		RCC_CFGR &= ~(0xf << 24);
+		RCC_CFGR |= (RCC_CFGR_MCO_HSE << 24);
+		gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
+		GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO8);
+	}
+	if (rev < 2) {
+		gpio_clear(GPIOA, GPIO12);
+		gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
+					  GPIO_CNF_OUTPUT_OPENDRAIN, GPIO12);
+	}
+	return rev;
+}
+
+void platform_request_boot(void)
+{
+	uint32_t crl = GPIOA_CRL;
+	/* Assert bootloader marker.
+	 * Enable Pull on GPIOA1. We don't rely on the external pin
+	 * really pulled, but only on the value of the CNF register
+	 * changed from the reset value
+	 */
+	crl &= 0xffffff0f;
+	crl |= 0x80;
+	GPIOA_CRL = crl;
+	SCB_VTOR = 0;
+}


### PR DESCRIPTION
I've modified the STLink platform make it use the alread-soldered SWD pins and the built-in LED. Also, since it is necessary to have a non-USB bootloader method of programming a new Blue Pill anyways, I had it build to be flashed directly rather than going through the DFU bootloader.