### PR TITLE
Probe halted

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -57,6 +57,7 @@ static bool cmd_swdp_scan(void);
 static bool cmd_targets(void);
 static bool cmd_morse(void);
 static bool cmd_assert_srst(target *t, int argc, const char **argv);
+static bool cmd_halt_timeout(target *t, int argc, const char **argv);
 static bool cmd_hard_srst(void);
 #ifdef PLATFORM_HAS_POWER_SWITCH
 static bool cmd_target_power(target *t, int argc, const char **argv);
@@ -76,6 +77,7 @@ const struct command_s cmd_list[] = {
 	{"targets", (cmd_handler)cmd_targets, "Display list of available targets" },
 	{"morse", (cmd_handler)cmd_morse, "Display morse error message" },
 	{"assert_srst", (cmd_handler)cmd_assert_srst, "Assert SRST until:(never(default)| scan | attach)" },
+	{"halt_timeout", (cmd_handler)cmd_halt_timeout, "Timeout (ms) to wait until Cortex-M is halted: (Default 2000)" },
 	{"hard_srst", (cmd_handler)cmd_hard_srst, "Force a pulse on the hard SRST line - disconnects target" },
 #ifdef PLATFORM_HAS_POWER_SWITCH
 	{"tpwr", (cmd_handler)cmd_target_power, "Supplies power to the target: (enable|disable)"},
@@ -93,6 +95,7 @@ static enum assert_srst_t assert_srst;
 #ifdef PLATFORM_HAS_DEBUG
 bool debug_bmp;
 #endif
+long cortexm_wait_timeout = 2000; /* Timeout to wait for Cortex to react on halt command. */
 
 int command_process(target *t, char *cmd)
 {
@@ -268,6 +271,16 @@ static bool cmd_assert_srst(target *t, int argc, const char **argv)
 	gdb_outf("Assert SRST %s\n",
 			 (assert_srst == ASSERT_UNTIL_ATTACH) ? "until attach" :
 			 (assert_srst == ASSERT_UNTIL_SCAN) ? "until scan" : "never");
+	return true;
+}
+
+static bool cmd_halt_timeout(target *t, int argc, const char **argv)
+{
+	(void)t;
+	if (argc > 1)
+		cortexm_wait_timeout = atol(argv[1]);
+	gdb_outf("Cortex-M timeout to wait for device haltes: %d\n",
+				 cortexm_wait_timeout);
 	return true;
 }
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -246,11 +246,12 @@ static uint32_t adiv5_mem_read32(ADIv5_AP_t *ap, uint32_t addr)
 	return ret;
 }
 
-static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
+static bool adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
 {
 	addr &= ~3;
 	uint64_t pidr = 0;
 	uint32_t cidr = 0;
+	bool res = false;
 
 	/* Assemble logical Product ID register value. */
 	for (int i = 0; i < 4; i++) {
@@ -270,14 +271,14 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
 
 	if (adiv5_dp_error(ap->dp)) {
 		DEBUG("Fault reading ID registers\n");
-		return;
+		return false;
 	}
 
 	/* CIDR preamble sanity check */
 	if ((cidr & ~CID_CLASS_MASK) != CID_PREAMBLE) {
 		DEBUG("0x%"PRIx32": 0x%"PRIx32" <- does not match preamble (0x%X)\n",
                       addr, cidr, CID_PREAMBLE);
-		return;
+		return false;
 	}
 
 	/* Extract Component ID class nibble */
@@ -296,7 +297,7 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
 			if ((entry & 1) == 0)
 				continue;
 
-			adiv5_component_probe(ap, addr + (entry & ~0xfff));
+			res |= adiv5_component_probe(ap, addr + (entry & ~0xfff));
 		}
 	} else {
 		/* Check if the component was designed by ARM, we currently do not support,
@@ -305,7 +306,7 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
 		if ((pidr & ~(PIDR_REV_MASK | PIDR_PN_MASK)) != PIDR_ARM_BITS) {
 			DEBUG("0x%"PRIx32": 0x%"PRIx64" <- does not match ARM JEP-106\n",
                               addr, pidr);
-			return;
+			return false;
 		}
 
 		/* Extract part number from the part id register. */
@@ -329,6 +330,7 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
 					      cidc_debug_strings[cid_class],
 					      cidc_debug_strings[pidr_pn_bits[i].cidc]);
 				}
+				res = true;
 				switch (pidr_pn_bits[i].arch) {
 				case aa_cortexm:
 					DEBUG("-> cortexm_probe\n");
@@ -349,6 +351,7 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr)
 			      cidc_debug_strings[cid_class], pidr);
 		}
 	}
+	return res;
 }
 
 ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel)
@@ -388,6 +391,7 @@ ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel)
 
 void adiv5_dp_init(ADIv5_DP_t *dp)
 {
+	volatile bool probed = false;
 	volatile uint32_t ctrlstat = 0;
 
 	adiv5_dp_ref(dp);
@@ -452,7 +456,11 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 		 */
 
 		/* The rest sould only be added after checking ROM table */
-		adiv5_component_probe(ap, ap->base);
+		probed |= adiv5_component_probe(ap, ap->base);
+		if (!probed && (dp->idcode & 0xfff) == 0x477) {
+			DEBUG("-> cortexm_probe forced\n");
+			cortexm_probe(ap);
+		}
 	}
 	adiv5_dp_unref(dp);
 }

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -252,7 +252,7 @@ static bool cortexm_forced_halt(target *t)
 	start_time = platform_time_ms();
 	/* Try hard to halt the target. STM32F7 in  WFI
 	   needs multiple writes!*/
-	while (platform_time_ms() < start_time + 2000) {
+	while (platform_time_ms() < start_time + cortexm_wait_timeout) {
 		dhcsr = target_mem_read32(t, CORTEXM_DHCSR);
 		if (dhcsr == (CORTEXM_DHCSR_S_HALT | CORTEXM_DHCSR_S_REGRDY |
 					  CORTEXM_DHCSR_C_HALT | CORTEXM_DHCSR_C_DEBUGEN))

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -22,6 +22,7 @@
 #include "target.h"
 #include "adiv5.h"
 
+extern long cortexm_wait_timeout;
 /* Private peripheral bus base address */
 #define CORTEXM_PPB_BASE	0xE0000000
 


### PR DESCRIPTION
This RP has now single issue commits with debug output removed. It  also allows the user to configure when to release SRST when asserted and how long to wait for the device halted is requested. This fixes issues with STML0 and F7 devices when WFI is used.