### PR TITLE
Removed debug bits for F4/F7 target, same as all other MCUs now

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -101,15 +101,6 @@ static int stm32f4_flash_write(struct target_flash *f,
 #define DBGMCU_IDCODE	0xE0042000
 #define ARM_CPUID	0xE000ED00
 
-#define DBGMCU_CR		0xE0042004
-#define DBG_STANDBY		(1 << 0)
-#define DBG_STOP		(1 << 1)
-#define DBG_SLEEP		(1 << 2)
-
-#define DBGMCU_APB1_FZ	0xE0042008
-#define DBG_WWDG_STOP	(1 << 11)
-#define DBG_IWDG_STOP	(1 << 12)
-
 #define AXIM_BASE 0x8000000
 #define ITCM_BASE 0x0200000
 
@@ -280,7 +271,6 @@ static bool stm32f4_attach(target *t)
 	default:
 		return false;
 	}
-	target_mem_write32(t, DBGMCU_CR, DBG_STANDBY| DBG_STOP | DBG_SLEEP);
 	bool use_dual_bank = false;
 	target_mem_map_free(t);
 	uint32_t flashsize = target_mem_read32(t, flashsize_base) & 0xffff;


### PR DESCRIPTION
I removed the debug bits which are being set in the F4/F7 target, so that it converges to the other targets and makes low-power development work as expected.
When the bits are set by the debugger one has to fight the debugger when doing low-power work, plus the user have to know the internal workings of the BMP to understand why the power measurements are all wrong.

I have been testing this for one day now on an F4 and F7 board, and it is working as expected now.