### PR TITLE
Fixes option erase for some STMF0 chips.

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -330,6 +330,9 @@ static bool stm32f1_cmd_option(target *t, int argc, char *argv[])
 	case 0x438:  /* STM32F303x6/8 and STM32F328 */
 	case 0x440:  /* STM32F0 */
 	case 0x446:  /* STM32F303xD/E and STM32F398xE */
+	case 0x445:  /* STM32F04 RM0091 Rev.7, STM32F070x6 RM0360 Rev. 4*/
+	case 0x448:  /* STM32F07 RM0091 Rev.7, STM32F070xB RM0360 Rev. 4*/
+	case 0x442:  /* STM32F09 RM0091 Rev.7, STM32F030xC RM0360 Rev. 4*/
 		flash_obp_rdp_key = FLASH_OBP_RDP_KEY_F3;
 		break;
 	default: flash_obp_rdp_key = FLASH_OBP_RDP_KEY;


### PR DESCRIPTION
I verified that this fixes option erase for STM32F070F6P6.  Per reference manual, it should also fix for other STMs with identical option byte protection.