### PR TITLE
Remove the sleep from the platforms and add it to the needed places

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -170,8 +170,11 @@ static bool cmd_jtag_scan(target *t, int argc, char **argv)
 
 	if(assert_srst != ASSERT_NEVER)
 		platform_srst_set_val(true);
-	if(assert_srst == ASSERT_UNTIL_SCAN)
+	if(assert_srst == ASSERT_UNTIL_SCAN) {
+		for (int i = 0; i < 10000; i++)
+			asm("nop");
 		platform_srst_set_val(false);
+	}
 
 	int devs = -1;
 	volatile struct exception e;
@@ -203,9 +206,11 @@ bool cmd_swdp_scan(void)
 
 	if(assert_srst != ASSERT_NEVER)
 		platform_srst_set_val(true);
-	if(assert_srst == ASSERT_UNTIL_SCAN)
+	if(assert_srst == ASSERT_UNTIL_SCAN) {
+		for (int i = 0; i < 10000; i++)
+			asm("nop");
 		platform_srst_set_val(false);
-
+	}
 	int devs = -1;
 	volatile struct exception e;
 	TRY_CATCH (e, EXCEPTION_ALL) {
@@ -288,6 +293,8 @@ static bool cmd_hard_srst(void)
 {
 	target_list_free();
 	platform_srst_set_val(true);
+	for (int i = 0; i < 10000; i++)
+		asm("nop");
 	platform_srst_set_val(false);
 	return true;
 }

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -92,13 +92,10 @@ platform_init(void)
 
 void platform_srst_set_val(bool assert)
 {
-	volatile int i;
-	if (assert) {
+	if (assert)
 		gpio_clear(SRST_PORT, SRST_PIN);
-		for(i = 0; i < 10000; i++) asm("nop");
-	} else {
+	else
 		gpio_set(SRST_PORT, SRST_PIN);
-	}
 }
 
 bool platform_srst_get_val(void)

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -189,9 +189,6 @@ void platform_srst_set_val(bool assert)
 	} else {
 		gpio_set_val(SRST_PORT, SRST_PIN, !assert);
 	}
-	if (assert) {
-		for(int i = 0; i < 10000; i++) asm("nop");
-	}
 }
 
 bool platform_srst_get_val(void)

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -521,6 +521,8 @@ static void cortexa_reset(target *t)
 
 	/* Try hard reset too */
 	platform_srst_set_val(true);
+	for(int i = 0; i < 10000; i++)
+		asm("nop");
 	platform_srst_set_val(false);
 
 	/* Spin until Xilinx reconnects us */

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -511,6 +511,8 @@ static void cortexm_reset(target *t)
 {
 	if ((t->target_options & CORTEXM_TOPT_INHIBIT_SRST) == 0) {
 		platform_srst_set_val(true);
+		for(int i = 0; i < 10000; i++)
+			asm("nop");
 		platform_srst_set_val(false);
 	}
 


### PR DESCRIPTION
Hi all,

I ran into an issue with my ST-Link where the reset (via SRST) was not working. I found out that the `platform_srst_set_val` was missing the 1000-nop-sleep.

Instead of adding it there I think it would make more sense to add it in places where the sleep is actually needed. This prevents other developers from forgetting this in other platforms.

From my opinion this is also more intuitive since adding a 1000-nop-sleep when the value is true doesn't make any sense.
