### PR TITLE
Move the LPC17xx probe function down

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -335,7 +335,6 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	PROBE(stm32l4_probe);
 	PROBE(lpc11xx_probe);
 	PROBE(lpc15xx_probe);
-	PROBE(lpc17xx_probe);
 	PROBE(lpc43xx_probe);
 	PROBE(sam3x_probe);
 	PROBE(sam4l_probe);
@@ -345,6 +344,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	PROBE(kinetis_probe);
 	PROBE(efm32_probe);
 	PROBE(msp432_probe);
+	PROBE(lpc17xx_probe);
 #undef PROBE
 
 	return true;


### PR DESCRIPTION
 since it performs an IAP call which can hang when performed on other devices than a LPC17xx. Fixes #388 

I've checked the other LPCxx probes, but they don't use IAP for probing.