### PR TITLE
adiv5_swdp: Add extra idle cycles with write transactions.

### DIFF
--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -159,6 +159,17 @@ static uint32_t adiv5_swdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 			raise_exception(EXCEPTION_ERROR, "SWDP Parity error");
 	} else {
 		swdptap_seq_out_parity(value, 32);
+		/* RM0377 Rev. 8 Chapter 27.5.4 for STM32L0x1 states:
+		 * Because of the asynchronous clock domains SWCLK and HCLK,
+		 * two extra SWCLK cycles are needed after a write transaction
+		 * (after the parity bit) to make the write effective
+		 * internally. These cycles should be applied while driving
+		 * the line low (IDLE state)
+		 * This is particularly important when writing the CTRL/STAT
+		 * for a power-up request. If the next transaction (requiring
+		 * a power-up) occurs immediately, it will fail.
+		 */
+		swdptap_seq_out(0, 2);
 	}
 
 	return response;

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -414,8 +414,6 @@ void cortexm_detach(target *t)
 
 	/* Disable debug */
 	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY);
-	/* Add some clock cycles to get the CPU running again.*/
-	target_mem_read32(t, 0);
 }
 
 enum { DB_DHCSR, DB_DCRSR, DB_DCRDR, DB_DEMCR };


### PR DESCRIPTION
These extra cycles are needed by some CPU, e.g. STM32L0x1 to cross the SWCLK
/HCLK domains. Revert insufficient #373 also tackling that problem.

Thanks to Thorsten von Eicken for pointing out.