### PR TITLE
Add slight delay to cortexm_reset

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -31,6 +31,7 @@
 #include "target.h"
 #include "target_internal.h"
 #include "cortexm.h"
+#include "platform.h"
 
 #include <unistd.h>
 
@@ -532,6 +533,11 @@ static void cortexm_reset(target *t)
 
 	/* Reset DFSR flags */
 	target_mem_write32(t, CORTEXM_DFSR, CORTEXM_DFSR_RESETALL);
+
+	/* 1ms delay to ensure that things such as the stm32f1 HSI clock have started
+	 * up fully.
+	 */
+	platform_delay(1);
 }
 
 static void cortexm_halt_request(target *t)

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -202,8 +202,10 @@ static int stm32f1_flash_erase(struct target_flash *f,
 
 		/* Read FLASH_SR to poll for BSY bit */
 		while (target_mem_read32(t, FLASH_SR) & FLASH_SR_BSY)
-			if(target_check_error(t))
+			if(target_check_error(t)) {
+				DEBUG("stm32f1 flash erase: comm error\n");
 				return -1;
+			}
 
 		len -= f->blocksize;
 		addr += f->blocksize;
@@ -211,8 +213,10 @@ static int stm32f1_flash_erase(struct target_flash *f,
 
 	/* Check for error */
 	sr = target_mem_read32(t, FLASH_SR);
-	if ((sr & SR_ERROR_MASK) || !(sr & SR_EOP))
+	if ((sr & SR_ERROR_MASK) || !(sr & SR_EOP)) {
+		DEBUG("stm32f1 flash erase error 0x%" PRIx32 "\n", sr);
 		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
While playing with [these](https://robotdyn.com/stm32f103-stm32-arm-mini-system-dev-board-stm-firmware.html) boards as both bmp host and target, I found that every other gdb `load` command failed with an erase error.

After some debugging, I determined that it only happened after a target reset, and that loads that didn't involve a reset went through fine. After some more debugging and googling, I happened upon [this thread](https://community.st.com/s/question/0D50X00009kKtahSAC/flash-page-erase-operation-never-completes), which lead me to suspect an HSI-related timing issue.

Sure enough, adding a loop to poll for `RCC_CR_HSIRDY` before attempting to erase the flash solved the problem and allowed *every* load to succeed.

@UweBonnes suggested a generic delay in `cortexm_reset` instead, since that would be a more generic solution.