### PR TITLE
libftdi: Allow to compile with mingw and cygwin and use recent libftdi1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,39 @@ sudo: required
 before_install:
   - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
   - sudo apt-get update -qq
-  - sudo apt-get install -y build-essential libftdi-dev gcc-arm-embedded
   - pip install --user intelhex
+  - gpg --recv-keys 3CEA9B8868BC3852618EB5B4707F91A424F006F5
+  - wget http://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.2.tar.bz2
+  - wget http://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.2.tar.bz2.sig
+  - gpg --trust-model always --verify libftdi1-1.2.tar.bz2.sig
+  - tar -xjf libftdi1-1.2.tar.bz2
+  - sudo apt-get install -y build-essential libboost-all-dev gcc-arm-embedded libusb-1.0-0-dev
 
-install: true
+install:
+  - cd libftdi1-1.2
+  - if [ "$TRAVIS_OS_NAME" = "linux" ];
+    then
+      sudo apt-get update -qq;
+      if [ "$ARCH" = "x86_64" ];
+      then
+        sudo apt-get install -qq libusb-1.0-0-dev;
+      elif [ "$ARCH" = "i386" ];
+      then
+        sudo apt-get install -qq gcc-multilib libusb-1.0-0-dev:i386 pkg-config:i386;
+        export CFLAGS="-m32";
+      fi
+    fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ];
+    then
+      brew update;
+      brew install libusb;
+    fi
+  - mkdir build
+  - cd build
+  - cmake ../
+  - make
+  - sudo make install
+  - cd ../../
 
 script:
   - make -C libopencm3 lib

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <inttypes.h>
+#include <sys/types.h>
 
 #include "platform.h"
 #include "platform_support.h"
@@ -43,6 +44,16 @@
 #define MIN(x, y)  (((x) < (y)) ? (x) : (y))
 #undef MAX
 #define MAX(x, y)  (((x) > (y)) ? (x) : (y))
+
+#ifdef _WIN32
+#  ifdef _WIN64
+#    define PRI_SIZET PRIu64
+#  else
+#    define PRI_SIZET PRIu32
+#  endif
+#else
+#  define PRI_SIZET "zu"
+#endif
 
 #endif
 

--- a/src/platforms/libftdi/Makefile.inc
+++ b/src/platforms/libftdi/Makefile.inc
@@ -1,4 +1,10 @@
+SYS = $(shell $(CC) -dumpmachine)
 CFLAGS += -DLIBFTDI
-LDFLAGS += -lftdi -lusb
-
+LDFLAGS += -lftdi1
+ifneq (, $(findstring mingw, $(SYS)))
+LDFLAGS +=  -lusb-1.0 -lws2_32
+CFLAGS += -Wno-cast-function-type
+else ifneq (, $(findstring cygwin, $(SYS)))
+LDFLAGS +=  -lusb-1.0 -lws2_32
+endif
 SRC += 	timing.c	\

--- a/src/platforms/libftdi/README.md
+++ b/src/platforms/libftdi/README.md
@@ -1,0 +1,14 @@
+Compiling on windows
+
+You can crosscompile blackmagic for windows with mingw or on windows
+with cygwin. For compilation, headers for libftdi1 and libusb-1.0 are
+needed. For running, libftdi1.dll and libusb-1.0.dll are needed and
+the executable must be able to find them. Mingw on cygwin does not provide
+a libftdi package yet.
+
+To prepare libusb access to the ftdi device, run zadig https://zadig.akeo.ie/.
+Choose WinUSB(libusb-1.0) for the BMP Ftdi device.
+
+Running cygwin/blackmagic in a cygwin console, the program does not react
+on ^C. In another console, run "ps ax" to find the WINPID of the process
+and then "taskkill /F ?PID (WINPID)".

--- a/src/platforms/libftdi/gdb_if.c
+++ b/src/platforms/libftdi/gdb_if.c
@@ -22,19 +22,19 @@
  * Serial Debugging protocol is implemented.  This implementation for Linux
  * uses a TCP server on port 2000.
  */
-#include <stdio.h>
 
-#ifndef WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
+#   include <winsock2.h>
+#   include <windows.h>
+#   include <ws2tcpip.h>
+#else
 #   include <sys/socket.h>
 #   include <netinet/in.h>
 #   include <netinet/tcp.h>
 #   include <sys/select.h>
-#else
-#   include <winsock2.h>
-#   include <windows.h>
-#   include <ws2tcpip.h>
 #endif
 
+#include <stdio.h>
 #include <assert.h>
 
 #include "general.h"
@@ -44,7 +44,7 @@ static int gdb_if_serv, gdb_if_conn;
 
 int gdb_if_init(void)
 {
-#ifdef WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 	WSADATA wsaData;
 	WSAStartup(MAKEWORD(2, 2), &wsaData);
 #endif
@@ -93,7 +93,11 @@ unsigned char gdb_if_getchar(void)
 unsigned char gdb_if_getchar_to(int timeout)
 {
 	fd_set fds;
+# if defined(__CYGWIN__)
+        TIMEVAL tv;
+#else
 	struct timeval tv;
+#endif
 
 	if(gdb_if_conn == -1) return -1;
 
@@ -111,7 +115,11 @@ unsigned char gdb_if_getchar_to(int timeout)
 
 void gdb_if_putchar(unsigned char c, int flush)
 {
+#if defined(__WIN32__) || defined(__CYGWIN__)
+	static char buf[2048];
+#else
 	static uint8_t buf[2048];
+#endif
 	static int bufsize = 0;
 	if (gdb_if_conn > 0) {
 		buf[bufsize++] = c;

--- a/src/platforms/libftdi/jtagtap.c
+++ b/src/platforms/libftdi/jtagtap.c
@@ -30,8 +30,6 @@
 
 #include <assert.h>
 
-#include <ftdi.h>
-
 #include "general.h"
 #include "jtagtap.h"
 

--- a/src/platforms/libftdi/platform.c
+++ b/src/platforms/libftdi/platform.c
@@ -286,7 +286,7 @@ int platform_buffer_read(uint8_t *data, int size)
 	return size;
 }
 
-#ifdef WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #warning "This vasprintf() is dubious!"
 int vasprintf(char **strp, const char *fmt, va_list ap)
 {

--- a/src/platforms/libftdi/platform.h
+++ b/src/platforms/libftdi/platform.h
@@ -21,11 +21,11 @@
 #ifndef __PLATFORM_H
 #define __PLATFORM_H
 
-#include <ftdi.h>
+#include <libftdi1/ftdi.h>
 
 #include "timing.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 #	include <alloca.h>
 #else
 #	ifndef alloca

--- a/src/platforms/libftdi/swdptap.c
+++ b/src/platforms/libftdi/swdptap.c
@@ -24,7 +24,6 @@
 
 #include <stdio.h>
 #include <assert.h>
-#include <ftdi.h>
 
 #include "general.h"
 #include "swdptap.h"
@@ -186,7 +185,7 @@ uint32_t swdptap_seq_in(int ticks)
 void swdptap_seq_out(uint32_t MS, int ticks)
 {
 	uint8_t cmd[15];
-	uint index = 0;
+	unsigned int index = 0;
 	swdptap_turnaround(0);
 	while (ticks) {
 		cmd[index++] = MPSSE_TMS_SHIFT;
@@ -209,7 +208,7 @@ void swdptap_seq_out_parity(uint32_t MS, int ticks)
 	uint8_t parity = 0;
 	int steps = ticks;
 	uint8_t cmd[18];
-	uint index = 0;
+	unsigned int index = 0;
 	uint32_t data = MS;
 	swdptap_turnaround(0);
 	while (steps) {

--- a/src/target/msp432.c
+++ b/src/target/msp432.c
@@ -289,7 +289,7 @@ static int msp432_flash_write(struct target_flash *f, target_addr dest,
 	regs[1] = dest;              // Flash address to be write to in R1
 	regs[2] = len;               // Size of buffer to be flashed in R2
 
-	DEBUG("Writing 0x%04"PRIX32" bytes at 0x%08zX\n", dest, len);
+	DEBUG("Writing 0x%04" PRIX32 " bytes at 0x%08" PRI_SIZET "\n", dest, len);
 	/* Call ROM */
 	msp432_call_ROM(t, mf->FlashCtl_programMemory, regs);
 


### PR DESCRIPTION
Tested with x86_64-w64-mingw32-gcc-8.2.0 and cygwin gcc (GCC) 7.3.0.
Use libftdi1 unconditionally.
Try to convice github travis to use libftdi1.
Remove unportable "uint ". Thanks to jacereda for pointing out in #400.