### PR TITLE
Makefile: Add -Wnocast-function-type for compilation on gcc8.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ endif
 
 OPT_FLAGS ?= -O2
 
-CFLAGS += -Wall -Wextra -Werror -Wno-char-subscripts\
+CFLAGS += -Wall -Wextra -Werror -Wno-char-subscripts -Wno-cast-function-type \
 	$(OPT_FLAGS) -std=gnu99 -g3 -MD \
 	-I. -Iinclude -Iplatforms/common -I$(PLATFORM_DIR)
 LDFLAGS += $(OPT_FLAGS)


### PR DESCRIPTION
Older GCC versions do not warn for disabled warnings they do not know yet.
This patch is needed to compile with gcc8.