### PR TITLE
Fix missing makefile dependency

### DIFF
--- a/upgrade/Makefile
+++ b/upgrade/Makefile
@@ -12,6 +12,8 @@ OBJ =	bindata.o	\
 
 all: $(OUTFILE)
 
+bindata.o: ../src/blackmagic.bin
+
 $(OUTFILE) $(OUTFILE).exe: $(OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 


### PR DESCRIPTION
Add blackmagic.bin as dependency of bindata.o so that running make
in upgrade will correctly rebuild the upgrade tool if the main binary
has changed.