### PR TITLE
Support for STM32WB55xx

### DIFF
--- a/src/include/command.h
+++ b/src/include/command.h
@@ -24,6 +24,8 @@
 #include "target.h"
 
 int command_process(target *t, char *cmd);
+/* Erase one or more flash pages */
+extern bool monitor_cmd_erase_page(target *t, int argc, char *argv[]);
 
 #endif
 


### PR DESCRIPTION
Here is the STM32WB support promised long ago...
What is done:
- Flashing, erasing, debugging work as expected.
- Option command improved error checks: number format, right number of parameter.
Slightly changed behaviour (saner, IMO):
With no parameters, print the options words. With `erase` resets them to defaults. With `write` **only** the provided words are written in the options, the remaining ones are left untouched instead of being read and rewritten.
- New CPU2option command: changes the boot address and memory start for CPU2. Probably working only on preproduction HW: @zyp to be checked on final HW!
- A new erase_page command has been added:
`monitor erase_page <address> [number of pages]`
 it is written to be independent of the MCU, it relies only on info from the flash data structure, see discussion at #457 

What is not there - and probably cannot be easily implemented  (some docs are still not available):

- The possibility to lock/unlock the chip security (ESE/FSD bits); the final RM does not make any mention of the procedure, and according to it the chips come pre-secured from factory (it was different in an early version I have): the code just leave those alone.
- A way to flash the radio FW: while the pre-prod HW is "open", for the final one it seems you need to use the bootloader or OTA update (my HW does not have any bootloader, so I can't even try that).

This is a largish commit: though the structure was prepared in #456, still the changes are spread all over, mostly due to the need of parametrize the flash controller base register.