### PR TITLE
Removed redundant "-f" options from main Makefile and native/Makefile…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -86,8 +86,8 @@ blackmagic: include/version.h $(OBJ)
 
 clean:	host_clean
 	$(Q)echo "  CLEAN"
-	-$(Q)$(RM) -f *.o *.d *~ blackmagic $(HOSTFILES)
-	-$(Q)$(RM) -f platforms/*/*.o platforms/*/*.d mapfile include/version.h
+	-$(Q)$(RM) *.o *.d *~ blackmagic $(HOSTFILES)
+	-$(Q)$(RM) platforms/*/*.o platforms/*/*.d mapfile include/version.h
 
 all_platforms:
 	$(Q)set -e ;\

--- a/src/platforms/native/Makefile.inc
+++ b/src/platforms/native/Makefile.inc
@@ -34,5 +34,5 @@ blackmagic_dfu: usbdfu.o dfucore.o dfu_f1.o
 	$(Q)$(CC) $^ -o $@ $(LDFLAGS_BOOT)
 
 host_clean:
-	-$(Q)$(RM) -f blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex
+	-$(Q)$(RM) blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex
 


### PR DESCRIPTION
GNU make defines the "RM" variable as "rm -f". In the two edited files there is an extra "-f" for each usage of "RM".

The extra "-f" does not bother Linux builds, however, while working towards a Windows build the "RM" variable needs change and the added "-f" causes "clean" to fail.
