### PR TITLE
Native Windows builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -86,8 +86,12 @@ blackmagic: include/version.h $(OBJ)
 
 clean:	host_clean
 	$(Q)echo "  CLEAN"
-	-$(Q)$(RM) -f *.o *.d *~ blackmagic $(HOSTFILES)
-	-$(Q)$(RM) -f platforms/*/*.o platforms/*/*.d mapfile include/version.h
+ifeq ($(OS), Windows_NT)
+	-$(Q)$(shell del *.o, *.d, blackmagic*, $(HOSTFILES))
+else
+	-$(Q)$(RM) *.o *.d *~ blackmagic $(HOSTFILES)
+	-$(Q)$(RM) platforms/*/*.o platforms/*/*.d mapfile include/version.h
+endif
 
 all_platforms:
 	$(Q)set -e ;\
@@ -112,7 +116,10 @@ all_platforms:
 command.c: include/version.h
 
 include/version.h: FORCE
-	$(Q)echo "  GIT     include/version.h"
-	$(Q)echo "#define FIRMWARE_VERSION \"`git describe --always --dirty`\"" > $@
-
+	$(Q)echo " GIT include/version.h"
+ifeq ($(OS), Windows_NT)
+	$(Q)echo #define FIRMWARE_VERSION "$(shell git describe --always --dirty)" > $@
+else
+	$(Q)echo "#define FIRMWARE_VERSION \"$(shell git describe --always --dirty)\"" > $@
+endif
 -include *.d

--- a/src/platforms/native/Makefile.inc
+++ b/src/platforms/native/Makefile.inc
@@ -34,5 +34,8 @@ blackmagic_dfu: usbdfu.o dfucore.o dfu_f1.o
 	$(Q)$(CC) $^ -o $@ $(LDFLAGS_BOOT)
 
 host_clean:
-	-$(Q)$(RM) -f blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex
-
+ifeq ($(OS), Windows_NT)
+	-$(Q)$(shell del blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex)
+else
+	-$(Q)$(RM) blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex
+endif


### PR DESCRIPTION
THese changes allow for the building of the Black Magic Probe for all the current platforms, except the launchpad-icdi, on a Windows development machine. This is done without the need for Cygwin, using only PowerShell.

Note that the  "all_platforms" target is not tested and will not work. If the launchpad-icdi host is fixed then "all_platforms" may be added.