### PR TITLE
Removed redundant include file

### DIFF
--- a/src/include/target.h
+++ b/src/include/target.h
@@ -29,7 +29,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 typedef struct target_s target;
 typedef uint32_t target_addr;


### PR DESCRIPTION
I am trying to integrate a new platform into the BMP repo and my new platform uses a library from Microchip, the winc1500 driver that is a part of the MLA library. When the file "unistd.h" is included in "target.h" there is a function name clash for "close". Since this is a third party source library I did not want to edit it to resolve the clash, this would make maintenance difficult when library updates are released. Fortunately, the header file is not required for the build to succeed.

This change appears to have to effect on building any of the BMP platforms.