### PR TITLE
[adiv5] Improvements in ADIv5

### DIFF
--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -106,6 +106,18 @@
 #define ADIV5_AP_CSW_SIZE_WORD		(2u << 0)
 #define ADIV5_AP_CSW_SIZE_MASK		(7u << 0)
 
+/* AP Debug Base Address Register (BASE) */
+#define ADIV5_AP_BASE_BASEADDR		(0xFFFFF000u)
+#define ADIV5_AP_BASE_PRESENT		(1u << 0)
+
+
+/* ADIv5 Class 0x1 ROM Table Registers */
+#define ADIV5_ROM_MEMTYPE			0xFCC
+#define ADIV5_ROM_MEMTYPE_SYSMEM	(1u << 0)
+#define ADIV5_ROM_ROMENTRY_PRESENT  (1u << 0)
+#define ADIV5_ROM_ROMENTRY_OFFSET	(0xFFFFF000u)
+
+
 /* Constants to make RnW parameters more clear in code */
 #define ADIV5_LOW_WRITE		0
 #define ADIV5_LOW_READ		1
@@ -190,4 +202,3 @@ void adiv5_mem_write_sized(ADIv5_AP_t *ap, uint32_t dest, const void *src,
 						   size_t len, enum align align);
 
 #endif
-

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -129,7 +129,8 @@ enum stm32h7_regs
 #define OPTKEY2 0x4C5D6E7F
 
 #define DBGMCU_IDCODE	0x5c001000
-/* Access via 0xe00e1000 does not show device! */
+/* Access from processor address space.
+ * Access via the APB-D is at 0xe00e1000 */
 #define DBGMCU_IDC		(DBGMCU_IDCODE + 0)
 #define DBGMCU_CR		(DBGMCU_IDCODE + 4)
 #define DBGSLEEP_D1		(1 << 0)


### PR DESCRIPTION
* Reference latest version of the ARM specification
* ROM tables - more debug information, including printing SYSMEM bit
* MEM-AP - reject when Debug Base Address entry is not
  present/invalid. These would only have errored in
  adiv5_component_probe.
* Resolve note in STM32H7 driver with explaination