### PR TITLE
Generate DEBUG warnings and return if `malloc`/`calloc` fail.

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -372,6 +372,11 @@ ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel)
 
 	/* It's valid to so create a heap copy */
 	ap = malloc(sizeof(*ap));
+	if (!ap) {			/* malloc failed: heap exhaustion */
+		DEBUG("malloc: failed in %s\n", __func__);
+		return NULL;
+	}
+
 	memcpy(ap, &tmpap, sizeof(*ap));
 	adiv5_dp_ref(dp);
 

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -49,6 +49,10 @@ static void adiv5_jtagdp_abort(ADIv5_DP_t *dp, uint32_t abort);
 void adiv5_jtag_dp_handler(jtag_dev_t *dev)
 {
 	ADIv5_DP_t *dp = (void*)calloc(1, sizeof(*dp));
+	if (!dp) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
 
 	dp->dev = dev;
 	dp->idcode = dev->idcode;
@@ -109,4 +113,3 @@ static void adiv5_jtagdp_abort(ADIv5_DP_t *dp, uint32_t abort)
 	jtag_dev_write_ir(dp->dev, IR_ABORT);
 	jtag_dev_shift_dr(dp->dev, NULL, (const uint8_t*)&request, 35);
 }
-

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -48,6 +48,10 @@ int adiv5_swdp_scan(void)
 
 	target_list_free();
 	ADIv5_DP_t *dp = (void*)calloc(1, sizeof(*dp));
+	if (!dp) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return -1;
+	}
 
 	if (swdptap_init())
 		return -1;
@@ -179,4 +183,3 @@ static void adiv5_swdp_abort(ADIv5_DP_t *dp, uint32_t abort)
 {
 	adiv5_dp_write(dp, ADIV5_DP_ABORT, abort);
 }
-

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -323,8 +323,17 @@ bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 	target *t;
 
 	t = target_new();
+	if (!t) {
+		return false;
+	}
+
 	adiv5_ap_ref(apb);
 	struct cortexa_priv *priv = calloc(1, sizeof(*priv));
+	if (!priv) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return false;
+	}
+
 	t->priv = priv;
 	t->priv_free = free;
 	priv->apb = apb;

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -264,8 +264,17 @@ bool cortexm_probe(ADIv5_AP_t *ap, bool forced)
 	target *t;
 
 	t = target_new();
+	if (!t) {
+		return false;
+	}
+
 	adiv5_ap_ref(ap);
 	struct cortexm_priv *priv = calloc(1, sizeof(*priv));
+	if (!priv) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return false;
+	}
+
 	t->priv = priv;
 	t->priv_free = cortexm_priv_free;
 	priv->ap = ap;
@@ -1035,4 +1044,3 @@ static int cortexm_hostio_request(target *t)
 
 	return t->tc->interrupted;
 }
-

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -518,6 +518,11 @@ static void efm32_add_flash(target *t, target_addr addr, size_t length,
 			    size_t page_size)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
 	f->start = addr;
 	f->length = length;
 	f->blocksize = page_size;

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -105,7 +105,14 @@ static void kl_gen_add_flash(target *t, uint32_t addr, size_t length,
                              size_t erasesize, size_t write_len)
 {
 	struct kinetis_flash *kf = calloc(1, sizeof(*kf));
-	struct target_flash *f = &kf->f;
+	struct target_flash *f;
+
+	if (!kf) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f = &kf->f;
 	f->start = addr;
 	f->length = length;
 	f->blocksize = erasesize;
@@ -367,6 +374,10 @@ void kinetis_mdm_probe(ADIv5_AP_t *ap)
 	}
 
 	target *t = target_new();
+	if (!t) {
+		return;
+	}
+
 	adiv5_ap_ref(ap);
 	t->priv = ap;
 	t->priv_free = (void*)adiv5_ap_unref;

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -60,6 +60,11 @@ static const uint16_t lmi_flash_write_stub[] = {
 static void lmi_add_flash(target *t, size_t length)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
 	f->start = 0;
 	f->length = length;
 	f->blocksize = 0x400;

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -36,7 +36,14 @@ struct flash_param {
 struct lpc_flash *lpc_add_flash(target *t, target_addr addr, size_t length)
 {
 	struct lpc_flash *lf = calloc(1, sizeof(*lf));
-	struct target_flash *f = &lf->f;
+	struct target_flash *f;
+
+	if (!lf) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return NULL;
+	}
+
+	f = &lf->f;
 	f->start = addr;
 	f->length = length;
 	f->erase = lpc_flash_erase;

--- a/src/target/msp432.c
+++ b/src/target/msp432.c
@@ -148,7 +148,13 @@ const struct command_s msp432_cmd_list[] = {
 static void msp432_add_flash(target *t, uint32_t addr, size_t length, target_addr prot_reg)
 {
 	struct msp432_flash *mf = calloc(1, sizeof(*mf));
-	struct target_flash *f = &mf->f;
+	struct target_flash *f;
+	if (!mf) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f = &mf->f;
 	f->start = addr;
 	f->length = length;
 	f->blocksize = SECTOR_SIZE;
@@ -183,7 +189,7 @@ bool msp432_probe(target *t)
 
 	/* If we got till this point, we are most probably looking at a real TLV  */
 	/* Device Information structure. Now check for the correct device         */
-	switch (target_mem_read32(t, DEVID_ADDR)) { 
+	switch (target_mem_read32(t, DEVID_ADDR)) {
 	case DEVID_MSP432P401RIPZ:
 	case DEVID_MSP432P401RIZXH:
 	case DEVID_MSP432P401RIRGC:

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -98,6 +98,11 @@ static void nrf51_add_flash(target *t,
                             uint32_t addr, size_t length, size_t erasesize)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
 	f->start = addr;
 	f->length = length;
 	f->blocksize = erasesize;
@@ -370,6 +375,10 @@ void nrf51_mdm_probe(ADIv5_AP_t *ap)
 	}
 
 	target *t = target_new();
+	if (!t) {
+		return;
+	}
+
 	adiv5_ap_ref(ap);
 	t->priv = ap;
 	t->priv_free = (void*)adiv5_ap_unref;

--- a/src/target/nxpke04.c
+++ b/src/target/nxpke04.c
@@ -238,6 +238,11 @@ bool ke04_probe(target *t)
 
 	/* Add flash, all KE04 have same write and erase size */
 	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return false;
+	}
+
 	f->start     = FLASH_BASE_ADDR;
 	f->length    = flashsize;
 	f->blocksize = KE04_SECTOR_SIZE;

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -126,7 +126,14 @@ static void sam3_add_flash(target *t,
                            uint32_t eefc_base, uint32_t addr, size_t length)
 {
 	struct sam_flash *sf = calloc(1, sizeof(*sf));
-	struct target_flash *f = &sf->f;
+	struct target_flash *f;
+
+	if (!sf) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f = &sf->f;
 	f->start = addr;
 	f->length = length;
 	f->blocksize = SAM3_PAGE_SIZE;
@@ -142,7 +149,14 @@ static void sam4_add_flash(target *t,
                            uint32_t eefc_base, uint32_t addr, size_t length)
 {
 	struct sam_flash *sf = calloc(1, sizeof(*sf));
-	struct target_flash *f = &sf->f;
+	struct target_flash *f;
+
+	if (!sf) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f = &sf->f;
 	f->start = addr;
 	f->length = length;
 	f->blocksize = SAM4_PAGE_SIZE * 8;

--- a/src/target/sam4l.c
+++ b/src/target/sam4l.c
@@ -169,6 +169,11 @@ static const size_t __nvp_size[16] = {
 static void sam4l_add_flash(target *t, uint32_t addr, size_t length)
 {
 	struct target_flash *f = calloc(1, sizeof(struct target_flash));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
 	f->start = addr;
 	f->length = length;
 	f->blocksize = SAM4L_PAGE_SIZE;

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -350,6 +350,11 @@ struct samd_descr samd_parse_device_id(uint32_t did)
 static void samd_add_flash(target *t, uint32_t addr, size_t length)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
 	f->start = addr;
 	f->length = length;
 	f->blocksize = SAMD_ROW_SIZE;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -98,6 +98,11 @@ static void stm32f1_add_flash(target *t,
                               uint32_t addr, size_t length, size_t erasesize)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
 	f->start = addr;
 	f->length = length;
 	f->blocksize = erasesize;

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -136,7 +136,13 @@ static void stm32f4_add_flash(target *t,
 {
 	if (length == 0) return;
 	struct stm32f4_flash *sf = calloc(1, sizeof(*sf));
-	struct target_flash *f = &sf->f;
+	struct target_flash *f;
+	if (!sf) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f = &sf->f;
 	f->start = addr;
 	f->length = length;
 	f->blocksize = blocksize;

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -157,7 +157,14 @@ static void stm32h7_add_flash(target *t,
                               uint32_t addr, size_t length, size_t blocksize)
 {
 	struct stm32h7_flash *sf = calloc(1, sizeof(*sf));
-	struct target_flash *f =  &sf->f;
+	struct target_flash *f;
+
+	if (!sf) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f = &sf->f;
 	f->start = addr;
 	f->length = length;
 	f->blocksize = blocksize;

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -233,6 +233,11 @@ static void stm32l_add_flash(target *t,
                              uint32_t addr, size_t length, size_t erasesize)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
 	f->start = addr;
 	f->length = length;
 	f->blocksize = erasesize;
@@ -245,6 +250,11 @@ static void stm32l_add_flash(target *t,
 static void stm32l_add_eeprom(target *t, uint32_t addr, size_t length)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
 	f->start = addr;
 	f->length = length;
 	f->blocksize = 4;

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -239,7 +239,14 @@ static void stm32l4_add_flash(target *t,
                               uint32_t bank1_start)
 {
 	struct stm32l4_flash *sf = calloc(1, sizeof(*sf));
-	struct target_flash *f = &sf->f;
+	struct target_flash *f;
+
+	if (!sf) {			/* calloc failed: heap exhaustion */
+		DEBUG("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f = &sf->f;
 	f->start = addr;
 	f->length = length;
 	f->blocksize = blocksize;


### PR DESCRIPTION
This is will make debugging earier if this does happen, rather than
dereferencing the null pointer (or passing it to memcpy, or worse).