### PR TITLE
gdb_main: Always release CPU when detaching.

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -227,8 +227,10 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 
 		case 0x04:
 		case 'D':	/* GDB 'detach' command. */
-			if(cur_target)
+			if(cur_target) {
+				SET_RUN_STATE(1);
 				target_detach(cur_target);
+			}
 			last_target = cur_target;
 			cur_target = NULL;
 			gdb_putpacketz("OK");


### PR DESCRIPTION
Fixes #413, was PR #477