### PR TITLE
fix overwriting of still-needed value

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -110,8 +110,9 @@ void target_add_commands(target *t, const struct command_s *cmds, const char *na
 	}
 
 	if (t->commands) {
-		for (tc = t->commands; tc->next; tc = tc->next);
-		tc->next = tc;
+		struct target_command_s *tail;
+		for (tail = t->commands; tail->next; tail = tail->next);
+		tail->next = tc;
 	} else {
 		t->commands = tc;
 	}


### PR DESCRIPTION
this fixes a bug that was introduced in blackmagic PR #475 which lead to firmware crashes when connecting to a BMP more than once without a power-cycle.
