### PR TITLE
use SWIM pins as UART

### DIFF
--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -105,12 +105,11 @@
 #define IRQ_PRI_USB_VBUS	(14 << 4)
 #define IRQ_PRI_SWO_DMA			(1 << 4)
 
-#define USBUSART USART2
-#define USBUSART_CR1 USART2_CR1
-#define USBUSART_IRQ NVIC_USART2_IRQ
-#define USBUSART_CLK RCC_USART2
-#define USBUSART_PORT GPIOA
-#define USBUSART_TX_PIN GPIO2
+extern uint32_t USBUSART;
+extern uint32_t USBUSART_IRQ;
+extern uint32_t USBUSART_CLK;
+extern uint32_t USBUSART_PORT;
+extern uint32_t USBUSART_TX_PIN;
 #define USBUSART_ISR usart2_isr
 #define USBUSART_TIM TIM4
 #define USBUSART_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM4)

--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -62,7 +62,7 @@ void usbuart_init(void)
 	usart_enable(USBUSART);
 
 	/* Enable interrupts */
-	USBUSART_CR1 |= USART_CR1_RXNEIE;
+	usart_enable_rx_interrupt(USBUSART);
 	nvic_set_priority(USBUSART_IRQ, IRQ_PRI_USBUSART);
 	nvic_enable_irq(USBUSART_IRQ);
 


### PR DESCRIPTION
some STM ST-LINK/V2 also provide SWIM functionality to flash STM8.
the SWIM pins are connected to UART (USART1 REMAP):
- SWIM_RST is connected to PB6/USART1_TX
- SWIM is connected to PB7/USART1_RX (pulled up by 680R)

cheap ST-LINK/V2 clones in form of USB dongle with aluminium case
provide SWD and SWIM signals.
since blackmagic does not support SWIM functionality, the pins can
be re-used as UART port for the USB to UART bridge.

STM ST-LINK/V2 can also offer UART, using USART2, but then the
SWIM signals are not present.
this changes verifies if the SWIM signals are present and remaps
them to USART1 if this is the case.