### PR TITLE
Windows Build Fixes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -99,12 +99,8 @@ $(TARGET): include/version.h $(OBJ)
 
 clean:	host_clean
 	$(Q)echo "  CLEAN"
-ifeq ($(OS), Windows_NT)
-	-$(Q)$(shell del *.o, *.d, blackmagic*, $(HOSTFILES))
-else
 	-$(Q)$(RM) *.o *.d *~ blackmagic $(HOSTFILES)
 	-$(Q)$(RM) platforms/*/*.o platforms/*/*.d mapfile include/version.h
-endif
 
 all_platforms:
 	$(Q)set -e ;\
@@ -130,9 +126,5 @@ command.c: include/version.h
 
 include/version.h: FORCE
 	$(Q)echo " GIT include/version.h"
-ifeq ($(OS), Windows_NT)
-	$(Q)echo #define FIRMWARE_VERSION "$(shell git describe --always --dirty)" > $@
-else
 	$(Q)echo "#define FIRMWARE_VERSION \"$(shell git describe --always --dirty)\"" > $@
-endif
 -include *.d

--- a/src/platforms/native/Makefile.inc
+++ b/src/platforms/native/Makefile.inc
@@ -34,8 +34,4 @@ blackmagic_dfu: usbdfu.o dfucore.o dfu_f1.o
 	$(Q)$(CC) $^ -o $@ $(LDFLAGS_BOOT)
 
 host_clean:
-ifeq ($(OS), Windows_NT)
-	-$(Q)$(shell del blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex)
-else
 	-$(Q)$(RM) blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex
-endif


### PR DESCRIPTION
After update of GCC "make" the tests for Windows OS are no longer needed.

Tested "clean" and also built all platforms except "hyrdabus"