### PR TITLE
swlink: Remove redundant conditional usbart_init().

### DIFF
--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -111,9 +111,6 @@ void platform_init(void)
 
 	platform_timing_init();
 	cdcacm_init();
-	/* Don't enable UART if we're being debugged. */
-	if (!(SCS_DEMCR & SCS_DEMCR_TRCENA))
-		usbuart_init();
 	usbuart_init();
 }
 


### PR DESCRIPTION
Noticed in #506.