### PR TITLE
Allow STM32 flash script to be used with python3

### DIFF
--- a/scripts/dfu.py
+++ b/scripts/dfu.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # dfu.py: Access USB DFU class devices
-# Copyright (C) 2009  Black Sphere Technologies 
+# Copyright (C) 2009  Black Sphere Technologies
 # Written by Gareth McMullin <gareth@blacksphere.co.nz>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -17,12 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
- 
+
 import usb
 
 DFU_DETACH_TIMEOUT = 1000
 
-# DFU Requests 
+# DFU Requests
 DFU_DETACH = 0x00
 DFU_DNLOAD = 0x01
 DFU_UPLOAD = 0x02
@@ -87,40 +87,40 @@ class dfu_device(object):
 	def release(self):
 		self.handle.releaseInterface()
 	def detach(self, wTimeout=255):
-		self.handle.controlMsg(usb.ENDPOINT_OUT | usb.TYPE_CLASS | 
-			usb.RECIP_INTERFACE, DFU_DETACH, 
+		self.handle.controlMsg(usb.ENDPOINT_OUT | usb.TYPE_CLASS |
+			usb.RECIP_INTERFACE, DFU_DETACH,
 			None, value=wTimeout, index=self.index)
 
 	def download(self, wBlockNum, data):
 		self.handle.controlMsg(usb.ENDPOINT_OUT | usb.TYPE_CLASS |
 			usb.RECIP_INTERFACE, DFU_DNLOAD,
-			data, value=wBlockNum, index=self.index) 
+			data, value=wBlockNum, index=self.index)
 
 	def upload(self, wBlockNum, length):
-		return self.handle.controlMsg(usb.ENDPOINT_IN | 
+		return self.handle.controlMsg(usb.ENDPOINT_IN |
 			usb.TYPE_CLASS | usb.RECIP_INTERFACE, DFU_UPLOAD,
-			length, value=wBlockNum, index=self.index) 
+			length, value=wBlockNum, index=self.index)
 
 	def get_status(self):
-		buf = self.handle.controlMsg(usb.ENDPOINT_IN | 
+		buf = self.handle.controlMsg(usb.ENDPOINT_IN |
 			usb.TYPE_CLASS | usb.RECIP_INTERFACE, DFU_GETSTATUS,
-			6, index=self.index) 
+			6, index=self.index)
 		return dfu_status(buf)
-		
+
 	def clear_status(self):
-		self.handle.controlMsg(usb.ENDPOINT_OUT | usb.TYPE_CLASS | 
-			usb.RECIP_INTERFACE, DFU_CLRSTATUS, 
+		self.handle.controlMsg(usb.ENDPOINT_OUT | usb.TYPE_CLASS |
+			usb.RECIP_INTERFACE, DFU_CLRSTATUS,
 			"", index=0)
 
 	def get_state(self):
-		buf = self.handle.controlMsg(usb.ENDPOINT_IN | 
+		buf = self.handle.controlMsg(usb.ENDPOINT_IN |
 			usb.TYPE_CLASS | usb.RECIP_INTERFACE, DFU_GETSTATE,
-			1, index=self.index) 
+			1, index=self.index)
 		return buf[0]
 
 	def abort(self):
-		self.handle.controlMsg(usb.ENDPOINT_OUT | usb.TYPE_CLASS | 
-			usb.RECIP_INTERFACE, DFU_ABORT, 
+		self.handle.controlMsg(usb.ENDPOINT_OUT | usb.TYPE_CLASS |
+			usb.RECIP_INTERFACE, DFU_ABORT,
 			None, index=self.index)
 
 
@@ -138,7 +138,7 @@ class dfu_device(object):
 			if status.bState == STATE_DFU_IDLE:
 				return True
 
-			if ((status.bState == STATE_DFU_DOWNLOAD_SYNC) or 
+			if ((status.bState == STATE_DFU_DOWNLOAD_SYNC) or
 			    (status.bState == STATE_DFU_DOWNLOAD_IDLE) or
 			    (status.bState == STATE_DFU_MANIFEST_SYNC) or
 			    (status.bState == STATE_DFU_UPLOAD_IDLE) or
@@ -157,7 +157,7 @@ class dfu_device(object):
 
 			if ((status.bState == STATE_APP_DETACH) or
 			    (status.bState == STATE_DFU_MANIFEST_WAIT_RESET)):
-                		usb.reset(self.handle)
+				usb.reset(self.handle)
 				return False
 
 		raise Exception
@@ -178,16 +178,16 @@ def finddevs():
 if __name__ == "__main__":
 	devs = finddevs()
 	if not devs:
-		print "No devices found!"
+		print("No devices found!")
 		exit(-1)
 
 	for dfu in devs:
 		handle = dfu[0].open()
 		man = handle.getString(dfu[0].iManufacturer, 30)
 		product = handle.getString(dfu[0].iProduct, 30)
-		print "Device %s: ID %04x:%04x %s - %s" % (dfu[0].filename, 
-			dfu[0].idVendor, dfu[0].idProduct, man, product)
-		print "%r, %r" % (dfu[1], dfu[2])
+		print("Device %s: ID %04x:%04x %s - %s" % (dfu[0].filename,
+			dfu[0].idVendor, dfu[0].idProduct, man, product))
+		print("%r, %r" % (dfu[1], dfu[2]))
 
 
 

--- a/scripts/stm32_mem.py
+++ b/scripts/stm32_mem.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # stm32_mem.py: STM32 memory access using USB DFU class
-# Copyright (C) 2011  Black Sphere Technologies 
+# Copyright (C) 2011  Black Sphere Technologies
 # Copyright (C) 2017  Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
 # Written by Gareth McMullin <gareth@blacksphere.co.nz>
 #
@@ -88,7 +88,7 @@ def stm32_scan(args, test):
 		if test == True:
 			return
 
-		print "No DFU devices found!"
+		print("No DFU devices found!")
 		exit(-1)
 
 	for dev in devs:
@@ -101,7 +101,7 @@ def stm32_scan(args, test):
 			continue
 
 		man = dfudev.handle.getString(dfudev.dev.iManufacturer, 30)
-		if man == "Black Sphere Technologies":
+		if man == b"Black Sphere Technologies":
 			bmp = bmp + 1
 			bmp_devs.append(dev)
 
@@ -109,25 +109,25 @@ def stm32_scan(args, test):
 		if test == True:
 			return
 
-		print "No compatible device found\n"
+		print("No compatible device found\n")
 		exit(-1)
 
 	if bmp > 1 and not args.serial_target:
 		if test == True:
 			return
 
-		print "Found multiple devices:\n"
+		print("Found multiple devices:\n")
 		for dev in bmp_devs:
 			dfudev = dfu.dfu_device(*dev)
 			man = dfudev.handle.getString(dfudev.dev.iManufacturer, 30)
 			product = dfudev.handle.getString(dfudev.dev.iProduct, 96)
 			serial_no = dfudev.handle.getString(dfudev.dev.iSerialNumber, 30)
-			print "Device ID:\t %04x:%04x" % (dfudev.dev.idVendor, dfudev.dev.idProduct)
-			print "Manufacturer:\t %s" % man
-			print "Product:\t %s" % product
-			print "Serial:\t\t %s\n" % serial_no
+			print("Device ID:\t %04x:%04x" % (dfudev.dev.idVendor, dfudev.dev.idProduct))
+			print("Manufacturer:\t %s" % man)
+			print("Product:\t %s" % product)
+			print("Serial:\t\t %s\n" % serial_no)
 
-		print "Select device with serial number!"
+		print("Select device with serial number!")
 		exit (-1)
 
 	for dev in bmp_devs:
@@ -142,23 +142,23 @@ def stm32_scan(args, test):
 			if man == "Black Sphere Technologies":
 				break
 
-	print "Device ID:\t %04x:%04x" % (dfudev.dev.idVendor, dfudev.dev.idProduct)
-	print "Manufacturer:\t %s" % man
-	print "Product:\t %s" % product
-	print "Serial:\t\t %s" % serial_no
+	print("Device ID:\t %04x:%04x" % (dfudev.dev.idVendor, dfudev.dev.idProduct))
+	print("Manufacturer:\t %s" % man)
+	print("Product:\t %s" % product)
+	print("Serial:\t\t %s" % serial_no)
 
 	if args.serial_target and serial_no != args.serial_target:
-		print "Serial number doesn't match!\n"
+		print("Serial number doesn't match!\n")
 		exit(-2)
 
 	return dfudev
 
 if __name__ == "__main__":
-	print
-	print "USB Device Firmware Upgrade - Host Utility -- version 1.2"
-	print "Copyright (C) 2011  Black Sphere Technologies"
-	print "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>"
-	print
+	print("-")
+	print("USB Device Firmware Upgrade - Host Utility -- version 1.2")
+	print("Copyright (C) 2011  Black Sphere Technologies")
+	print("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>")
+	print("-")
 
 	parser = argparse.ArgumentParser()
 	parser.add_argument("progfile", help="Binary file to program")
@@ -171,12 +171,12 @@ if __name__ == "__main__":
 		state = dfudev.get_state()
 	except:
 		if args.manifest : exit(0)
-		print "Failed to read device state! Assuming APP_IDLE"
+		print("Failed to read device state! Assuming APP_IDLE")
 		state = dfu.STATE_APP_IDLE
 	if state == dfu.STATE_APP_IDLE:
 		dfudev.detach()
 		dfudev.release()
-		print "Invoking DFU Device"
+		print("Invoking DFU Device")
 		timeout = 0
 		while True :
 			sleep(0.5)
@@ -184,11 +184,11 @@ if __name__ == "__main__":
 			dfudev = stm32_scan(args, True)
 			if dfudev: break
 			if timeout > 5 :
-				print "Error: DFU device did not appear"
+				print("Error: DFU device did not appear")
 				exit(-1)
 	if args.manifest :
 		stm32_manifest(dfudev)
-		print "Invoking Application Device"
+		print("Invoking Application Device")
 		exit(0)
 	dfudev.make_idle()
 	file = open(args.progfile, "rb")
@@ -198,7 +198,7 @@ if __name__ == "__main__":
 	if args.address :
 		start = int(args.address, 0)
 	else :
-		if "F4" in product:
+		if b"F4" in product:
 			start = 0x8004000
 		else:
 			start = 0x8002000
@@ -213,12 +213,12 @@ if __name__ == "__main__":
 # get evaluated and erase called only once per sector!
 			stm32_erase(dfudev, addr)
 		except:
-			print "\nErase Timed out\n"
+			print("\nErase Timed out\n")
 			break
 		try:
 			stm32_set_address(dfudev, addr)
 		except:
-			print "\nSet Address Timed out\n"
+			print("\nSet Address Timed out\n")
 			break
 		stm32_write(dfudev, bin[:1024])
 		bin = bin[1024:]
@@ -227,8 +227,8 @@ if __name__ == "__main__":
 	bin = file.read()
 	len = len(bin)
 	addr = start
-        print
-        while bin:
+	print("-")
+	while bin:
 		try:
 			stm32_set_address(dfudev, addr)
 			data = stm32_read(dfudev)
@@ -236,7 +236,7 @@ if __name__ == "__main__":
 # Abort silent if bootloader does not support upload
 			break
 		print ("Verifying memory at   0x%08X\r" % addr),
-                stdout.flush()
+		stdout.flush()
 		if len > 1024 :
 			size = 1024
 		else :
@@ -248,7 +248,7 @@ if __name__ == "__main__":
 		addr += 1024
 		len -= 1024
 		if len <= 0 :
-			print "\nVerified!"
+			print("\nVerified!")
 	stm32_manifest(dfudev)
 
-	print "All operations complete!\n"
+	print("All operations complete!\n")


### PR DESCRIPTION
I modified the flash script and its dependency to have braces for print statements, allowing execution with python3.

Because every set of braces only includes 1 value (by keeping the string concatenation with % in place), even if python2 interpretes it as a tuple, it still prints it as previously. Therefore, this should be compatible with python2 and python3 at the same time.

Tested by flashing various stlink / stm32 boards with blackmagic probe firmware using python3.7.