### PR TITLE
stlink-ud for unidirectional isolators or level translators.

### DIFF
--- a/src/platforms/stlink-ud/Bootloader_Upgrade
+++ b/src/platforms/stlink-ud/Bootloader_Upgrade
@@ -1,0 +1,22 @@
+Bootloader Upgrade on Stlink
+============================
+
+Beside accessing the SWD pins direct like explained on
+https://embdev.net/articles/STM_Discovery_as_Black_Magic_Probe
+an updated bootloader can also be programmed via DFU. This requires three
+steps:
+1. Prepare bootloader update
+Normal BMP has to be replaced by the upgrade programm:
+ dfu-util -s 0x08002000:leave -D dfu_upgrade.bin
+Wait until Dual color led flashes red, indicating DFU is active for the
+bootloader.
+
+2. Flash new bootloader
+ dfu-util -s 0x08000000 -D blackmagic_dfu.bin
+Wait until Dual color led flashes green, indicating bootloader is active.
+
+If not, unplug USB, keep black reset button pressed, replug USB.
+Wait until Dual color led flashes green.
+
+3. Flash BMP
+ dfu-util -s 0x08002000:leave:force -D blackmagic.bin

--- a/src/platforms/stlink-ud/Connector
+++ b/src/platforms/stlink-ud/Connector
@@ -1,0 +1,7 @@
+== SWD Connector CN2 --
+1 VDD_TARGET VDD from application
+2   SWCLK    SWD clock
+3    GND     Ground
+4   SWDIO    SWD data input/output
+5    NRST    RESET of target MCU
+6    SWO     Reserved

--- a/src/platforms/stlink-ud/Flashsize_F103
+++ b/src/platforms/stlink-ud/Flashsize_F103
@@ -1,0 +1,53 @@
+Announced versus available Flash size on F103
+============================================
+Up to Stlink V2, the CPU soldered on the board was a F103C8 with 64 kiByte
+flash. Up to about version 280 of BMP, this limit was not hit when linked
+against nanolib.
+
+StlinkV2-1 has a STM32F103CB, like a genuine BMP.
+
+However with more and more devices supported, BMP at about version 282 hit
+this limit. There are two ways to work around:
+- Branch STlink V2-1 as separate platform and and care for the original STlink
+  platform by restricting/ommitting features.
+- Rely on uncertain upper flash on F103C8
+
+The first option needs more care as an additional platform is introduced and
+will restrict usage of older STlinks as BMPs.
+
+However F103C8 and F103CB have the same chip and upper flash exists on F103C8.
+This flash may have been tested bad, or not have been tested at all,
+or, in the best case, was tested good but market requirements made STM sell
+it as F103C8.
+
+Ignoring the chip marking and using an F103C8 blindly as a F103Cb is done
+already with few problems on many china boards (e.g. blue pill). Probably
+this second approach will work for many of the older STLinks.
+
+dfu-util cares for the size and refuses to programm above the announced size:
+ > dfu-util -S E4D078EA -s 0x08002000:leave -D blackmagic.bin
+ dfu-util 0.9
+ ...
+ dfu-util: Last page at 0x0801093f is not writeable
+
+Flash above the announced size with recent bootloader/BMP:
+==========================================================
+script/stm32_mem.py does not care for the announced size:
+ > ../scripts/stm32_mem.py blackmagic.bin
+ ...
+ USB Device Firmware Upgrade - Host Utility -- version 1.2
+ ...
+ Programming memory at 0x08010800
+ All operations complete!
+
+Get length of binary
+  > ls -l blackmagic.bin
+ -rwxr-xr-x 1 bon users 59712 21. Sep 22:47 blackmagic.bin
+Actual file size may differ!
+
+Upload binary from flash with the exact size
+  > dfu-util -s 0x08002000:leave:force:59712 -U blackmagic.bin.1
+
+Compare
+  > diff blackmagic.bin*
+No differences should get reported!

--- a/src/platforms/stlink-ud/Makefile.inc
+++ b/src/platforms/stlink-ud/Makefile.inc
@@ -1,0 +1,44 @@
+CROSS_COMPILE ?= arm-none-eabi-
+CC = $(CROSS_COMPILE)gcc
+OBJCOPY = $(CROSS_COMPILE)objcopy
+
+OPT_FLAGS = -Os
+CFLAGS += -mcpu=cortex-m3 -mthumb \
+	-DSTM32F1 -DDISCOVERY_STLINK -I../libopencm3/include \
+	-I platforms/stm32
+LDFLAGS_BOOT := $(LDFLAGS) --specs=nano.specs \
+	-lopencm3_stm32f1 -Wl,--defsym,_stack=0x20005000 \
+	-Wl,-T,platforms/stm32/stlink.ld -nostartfiles -lc \
+	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m3 -Wl,-gc-sections \
+	-L../libopencm3/lib
+LDFLAGS = $(LDFLAGS_BOOT) -Wl,-Ttext=0x8002000
+
+ifeq ($(ENABLE_DEBUG), 1)
+LDFLAGS += --specs=rdimon.specs
+else
+LDFLAGS += --specs=nosys.specs
+endif
+
+VPATH += platforms/stm32
+
+SRC += 	cdcacm.c	\
+	usbuart.c 	\
+	serialno.c	\
+	timing.c	\
+	timing_stm32.c	\
+	traceswoasync.c	\
+	stlink_common.c \
+
+all:	blackmagic.bin blackmagic_dfu.bin blackmagic_dfu.hex dfu_upgrade.bin dfu_upgrade.hex
+
+blackmagic_dfu: usbdfu.o dfucore.o dfu_f1.o stlink_common.o
+	@echo "  LD      $@"
+	$(Q)$(CC) $^ -o $@ $(LDFLAGS_BOOT)
+
+dfu_upgrade: dfu_upgrade.o dfucore.o dfu_f1.o  stlink_common.o
+	@echo "  LD      $@"
+	$(Q)$(CC) $^ -o $@ $(LDFLAGS)
+
+host_clean:
+	-$(Q)$(RM) blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex dfu_upgrade dfu_upgrade.bin dfu_upgrade.hex
+

--- a/src/platforms/stlink-ud/Readme
+++ b/src/platforms/stlink-ud/Readme
@@ -1,0 +1,17 @@
+Find a description how to modify a Discovery Board to use it's Stlink as
+black magic debug at
+http://embdev.net/articles/STM_Discovery_as_Black_Magic_Probe
+
+Differences between V1/V2
+
+                V1                V2
+ID Pins PC13/14 unconnected       PC 13 pulled low
+LED STLINK      PA8, active High  PA9, Dual Led
+MCO Out         NA                PA8
+RESET(Target)   T_JRST(PB1)       NRST (PB0)
+
+On the NucleoXXXP boards, e.g. NUCLEO-L4R5ZI (144 pin) or
+NUCLEO-L452RE-P (64 pins), by default nRst is not connected. To reach the
+target nRST pin with the "mon connect_srst enable" option, the right NRST
+jumper must be placed. On Nucleo144-P boards it is JP3, on NUCLEO64-P
+boards it is JP4.

--- a/src/platforms/stlink-ud/dfu_upgrade.c
+++ b/src/platforms/stlink-ud/dfu_upgrade.c
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2013 Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+#include <libopencm3/cm3/systick.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/cm3/scb.h>
+
+#include "usbdfu.h"
+#include "general.h"
+#include "platform.h"
+
+uint32_t app_address = 0x08000000;
+static uint16_t led_upgrade;
+static uint32_t led2_state = 0;
+extern uint32_t _stack;
+static uint32_t rev;
+
+void dfu_detach(void)
+{
+	platform_request_boot();
+	scb_reset_core();
+}
+
+int main(void)
+{
+	rev = detect_rev();
+	rcc_clock_setup_in_hse_8mhz_out_72mhz();
+	if (rev == 0)
+		led_upgrade = GPIO8;
+	else
+		led_upgrade = GPIO9;
+
+	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB_DIV8);
+	systick_set_reload(900000);
+
+	dfu_protect(UPD_MODE);
+
+	systick_interrupt_enable();
+	systick_counter_enable();
+
+	if (rev > 1) /* Reconnect USB */
+		gpio_set(GPIOA, GPIO15);
+	dfu_init(&st_usbfs_v1_usb_driver, UPD_MODE);
+
+	dfu_main();
+}
+
+void dfu_event(void)
+{
+}
+
+void sys_tick_handler(void)
+{
+	if (rev == 0) {
+		gpio_toggle(GPIOA, led_upgrade);
+	} else {
+		if (led2_state & 1) {
+			gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
+				GPIO_CNF_OUTPUT_PUSHPULL, led_upgrade);
+			gpio_set(GPIOA, led_upgrade);
+		} else {
+			gpio_set_mode(GPIOA, GPIO_MODE_INPUT,
+				GPIO_CNF_INPUT_ANALOG, led_upgrade);
+		}
+		led2_state++;
+	}
+}

--- a/src/platforms/stlink-ud/platform.c
+++ b/src/platforms/stlink-ud/platform.c
@@ -1,0 +1,121 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* This file implements the platform specific functions for the ST-Link
+ * implementation.
+ */
+
+#include "general.h"
+#include "cdcacm.h"
+#include "usbuart.h"
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/cm3/scb.h>
+#include <libopencm3/cm3/scs.h>
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/usb/usbd.h>
+#include <libopencm3/stm32/adc.h>
+
+uint8_t running_status;
+
+uint16_t led_idle_run;
+uint16_t srst_pin;
+static uint32_t rev;
+
+int platform_hwversion(void)
+{
+	return rev;
+}
+
+void platform_init(void)
+{
+	rev = detect_rev();
+	SCS_DEMCR |= SCS_DEMCR_VC_MON_EN;
+#ifdef ENABLE_DEBUG
+	void initialise_monitor_handles(void);
+	initialise_monitor_handles();
+#endif
+	rcc_clock_setup_in_hse_8mhz_out_72mhz();
+#if 0
+        led_idle_run = LED_PIN;
+#else
+	if (rev == 0) {
+		led_idle_run = GPIO8;
+		srst_pin = SRST_PIN_V1;
+	} else {
+		led_idle_run = GPIO9;
+		srst_pin = SRST_PIN_V2;
+	}
+#endif
+	/* Setup GPIO ports */
+        gpio_set_mode(TMS_PORT, GPIO_MODE_INPUT,
+                      GPIO_CNF_INPUT_PULL_UPDOWN, TMS_PIN);
+	gpio_set_mode(TCK_PORT, GPIO_MODE_OUTPUT_50_MHZ,
+	              GPIO_CNF_OUTPUT_PUSHPULL, TCK_PIN);
+	gpio_set_mode(TDI_PORT, GPIO_MODE_OUTPUT_50_MHZ,
+	              GPIO_CNF_OUTPUT_PUSHPULL, TDI_PIN);
+	gpio_set_mode(SWDDIR_PORT, GPIO_MODE_OUTPUT_50_MHZ,
+	              GPIO_CNF_OUTPUT_PUSHPULL, SWDDIR_PIN);
+	gpio_set_mode(SWDOUT_PORT, GPIO_MODE_OUTPUT_50_MHZ,
+	              GPIO_CNF_OUTPUT_PUSHPULL, SWDOUT_PIN);
+
+	platform_srst_set_val(false);
+
+	gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ,
+	              GPIO_CNF_OUTPUT_PUSHPULL, led_idle_run);
+
+	/* Relocate interrupt vector table here */
+	extern int vector_table;
+	SCB_VTOR = (uint32_t)&vector_table;
+
+	platform_timing_init();
+	if (rev > 1) /* Reconnect USB */
+		gpio_set(GPIOA, GPIO15);
+	cdcacm_init();
+	/* Don't enable UART if we're being debugged. */
+	if (!(SCS_DEMCR & SCS_DEMCR_TRCENA))
+		usbuart_init();
+}
+
+void platform_srst_set_val(bool assert)
+{
+	if (assert) {
+		gpio_set_mode(SRST_PORT, GPIO_MODE_OUTPUT_50_MHZ,
+		              GPIO_CNF_OUTPUT_OPENDRAIN, srst_pin);
+		gpio_clear(SRST_PORT, srst_pin);
+		while (gpio_get(SRST_PORT, srst_pin)) {};
+	} else {
+		gpio_set_mode(SRST_PORT, GPIO_MODE_INPUT,
+			GPIO_CNF_INPUT_PULL_UPDOWN, srst_pin);
+		gpio_set(SRST_PORT, srst_pin);
+		while (!gpio_get(SRST_PORT, srst_pin)) {};
+	}
+}
+
+bool platform_srst_get_val()
+{
+	return gpio_get(SRST_PORT, srst_pin) == 0;
+}
+
+const char *platform_target_voltage(void)
+{
+	return "unknown";
+}

--- a/src/platforms/stlink-ud/platform.h
+++ b/src/platforms/stlink-ud/platform.h
@@ -1,0 +1,177 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* This file implements the platform specific functions for the STM32
+ * implementation.
+ */
+#ifndef __PLATFORM_H
+#define __PLATFORM_H
+
+#include "gpio.h"
+#include "timing.h"
+#include "timing_stm32.h"
+#include "version.h"
+
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/stm32/f1/memorymap.h>
+#include <libopencm3/usb/usbd.h>
+
+#ifdef ENABLE_DEBUG
+# define PLATFORM_HAS_DEBUG
+# define USBUART_DEBUG
+#endif
+
+#define BOARD_IDENT       "Black Magic Probe (STLINK), (Firmware " FIRMWARE_VERSION ")"
+#define BOARD_IDENT_DFU   "Black Magic (Upgrade) for STLink/Discovery, (Firmware " FIRMWARE_VERSION ")"
+#define BOARD_IDENT_UPD   "Black Magic (DFU Upgrade) for STLink/Discovery, (Firmware " FIRMWARE_VERSION ")"
+#define DFU_IDENT         "Black Magic Firmware Upgrade (STLINK)"
+#define UPD_IFACE_STRING  "@Internal Flash   /0x08000000/8*001Kg"
+
+/* Hardware definitions... */
+#define TDI_PORT	GPIOA
+#define TDI_PIN		GPIO7
+#define TMS_PORT	GPIOA   /* SWDIO */
+#define TMS_PIN		GPIO4   /* SWDIO */
+#define TCK_PORT	GPIOA   /* SWCLK */
+#define TCK_PIN		GPIO5   /* SWCLK */
+#define TDO_PORT	GPIOA
+#define TDO_PIN		GPIO6
+
+#define SWDIO_PORT 	TMS_PORT
+#define SWDIO_PIN	TMS_PIN
+#define SWCLK_PORT 	TCK_PORT
+#define SWCLK_PIN	TCK_PIN
+#define SWDDIR_PORT 	GPIOA
+#define SWDDIR_PIN	GPIO6
+#define SWDOUT_PORT 	GPIOA
+#define SWDOUT_PIN	GPIO7
+
+/*
+  SWDIN		GPIOA 4
+  SWDIO input pin
+
+  SWDCLK	GPIOA 5
+
+  SWDDIR	GPIOA 6
+  SWDIO direction 0: out
+                  1: in
+
+  SWDOUT	GPIOA 7
+  SWDIO output
+ */
+
+#define SRST_PORT	GPIOB
+#define SRST_PIN_V1	GPIO1
+#define SRST_PIN_V2	GPIO0
+
+#define LED_PORT	GPIOA
+/* Use PC14 for a "dummy" uart led. So we can observere at least with scope*/
+#define LED_PORT_UART	GPIOC
+#define LED_UART	GPIO14
+
+#define PLATFORM_HAS_TRACESWO	1
+#define NUM_TRACE_PACKETS		(128)		/* This is an 8K buffer */
+
+# define SWD_CR   GPIO_CRH(SWDIO_PORT)
+# define SWD_CR_MULT (1 << ((14 - 8) << 2))
+
+#define TMS_SET_MODE() \
+    do { \
+	gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_50_MHZ,  \
+	              GPIO_CNF_OUTPUT_PUSHPULL, TMS_PIN); \
+    } while (0)
+#define SWDIO_MODE_FLOAT_Z() 	do { \
+	uint32_t cr = SWD_CR; \
+	cr  &= ~(0xf * SWD_CR_MULT); \
+	cr  |=  (0x4 * SWD_CR_MULT); \
+	SWD_CR = cr; \
+} while(0)
+#define SWDIO_MODE_DRIVE_Z() 	do { \
+	uint32_t cr = SWD_CR; \
+	cr  &= ~(0xf * SWD_CR_MULT); \
+	cr  |=  (0x1 * SWD_CR_MULT); \
+	SWD_CR = cr; \
+} while(0)
+#define UART_PIN_SETUP() \
+	gpio_set_mode(USBUSART_PORT, GPIO_MODE_OUTPUT_2_MHZ, \
+	              GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, USBUSART_TX_PIN);
+
+#define USB_DRIVER      st_usbfs_v1_usb_driver
+#define USB_IRQ	        NVIC_USB_LP_CAN_RX0_IRQ
+#define USB_ISR	        usb_lp_can_rx0_isr
+/* Interrupt priorities.  Low numbers are high priority.
+ * For now USART2 preempts USB which may spin while buffer is drained.
+ */
+#define IRQ_PRI_USB		(2 << 4)
+#define IRQ_PRI_USBUSART	(1 << 4)
+#define IRQ_PRI_USBUSART_TIM	(3 << 4)
+#define IRQ_PRI_USB_VBUS	(14 << 4)
+#define IRQ_PRI_SWO_DMA			(1 << 4)
+
+#define USBUSART USART2
+#define USBUSART_CR1 USART2_CR1
+#define USBUSART_IRQ NVIC_USART2_IRQ
+#define USBUSART_CLK RCC_USART2
+#define USBUSART_PORT GPIOA
+#define USBUSART_TX_PIN GPIO2
+#define USBUSART_ISR usart2_isr
+#define USBUSART_TIM TIM4
+#define USBUSART_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM4)
+#define USBUSART_TIM_IRQ NVIC_TIM4_IRQ
+#define USBUSART_TIM_ISR tim4_isr
+
+#ifdef ENABLE_DEBUG
+extern bool debug_bmp;
+int usbuart_debug_write(const char *buf, size_t len);
+# define DEBUG printf
+#else
+# define DEBUG(...)
+#endif
+
+/* On F103, only USART1 is on AHB2 and can reach 4.5 MBaud at 72 MHz.*/
+#define SWO_UART				USART1
+#define SWO_UART_DR				USART1_DR
+#define SWO_UART_CLK			RCC_USART1
+#define SWO_UART_PORT			GPIOA
+#define SWO_UART_RX_PIN			GPIO10
+
+/* This DMA channel is set by the USART in use */
+#define SWO_DMA_BUS				DMA1
+#define SWO_DMA_CLK				RCC_DMA1
+#define SWO_DMA_CHAN			DMA_CHANNEL5
+#define SWO_DMA_IRQ				NVIC_DMA1_CHANNEL5_IRQ
+#define SWO_DMA_ISR(x)			dma1_channel5_isr(x)
+
+extern uint16_t led_idle_run;
+#define LED_IDLE_RUN            led_idle_run
+#define SET_RUN_STATE(state)	{running_status = (state);}
+#define SET_IDLE_STATE(state)	{gpio_set_val(LED_PORT, led_idle_run, state);}
+#define SET_ERROR_STATE(x)
+
+extern uint32_t detect_rev(void);
+
+/* Use newlib provided integer only stdio functions */
+#define sscanf siscanf
+#define sprintf siprintf
+#define vasprintf vasiprintf
+#define snprintf sniprintf
+
+#endif
+

--- a/src/platforms/stlink-ud/stlink_common.c
+++ b/src/platforms/stlink-ud/stlink_common.c
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2017 Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/cm3/scb.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+/* return 0 for stlink V1, 1 for stlink V2 and 2 for stlink V2.1 */
+uint32_t detect_rev(void)
+{
+	uint32_t rev;
+	int res;
+
+	while (RCC_CFGR & 0xf) /* Switch back to HSI. */
+		RCC_CFGR &= ~3;
+	rcc_periph_clock_enable(RCC_GPIOA);
+	rcc_periph_clock_enable(RCC_GPIOB);
+	rcc_periph_clock_enable(RCC_GPIOC);
+	rcc_periph_clock_enable(RCC_USB);
+	rcc_periph_reset_pulse(RST_USB);
+	rcc_periph_clock_enable(RCC_AFIO);
+	rcc_periph_clock_enable(RCC_CRC);
+	/* First, get Board revision by pulling PC13/14 up. Read
+	 *  11 for ST-Link V1, e.g. on VL Discovery, tag as rev 0
+	 *  00 for ST-Link V2, e.g. on F4 Discovery, tag as rev 1
+	 *  01 for ST-Link V2, else,                 tag as rev 1
+	 */
+	gpio_set_mode(GPIOC, GPIO_MODE_INPUT,
+				  GPIO_CNF_INPUT_PULL_UPDOWN, GPIO14 | GPIO13);
+	gpio_set(GPIOC, GPIO14 | GPIO13);
+	for (int i = 0; i < 100; i ++)
+		res = gpio_get(GPIOC, GPIO13);
+	if (res)
+		rev = 0;
+	else {
+		/* Check for V2.1 boards.
+		 * PA15/TDI is USE_RENUM, pulled with 10 k to U5V on V2.1,
+		 * Otherwise unconnected. Enable pull low. If still high.
+		 * it is V2.1.*/
+		rcc_periph_clock_enable(RCC_AFIO);
+		AFIO_MAPR |= 0x02000000; /* Release from TDI.*/
+		gpio_set_mode(GPIOA, GPIO_MODE_INPUT,
+                                 GPIO_CNF_INPUT_PULL_UPDOWN, GPIO15);
+		gpio_clear(GPIOA, GPIO15);
+		for (int i = 0; i < 100; i++)
+			res =  gpio_get(GPIOA, GPIO15);
+		if (res) {
+			rev = 2;
+			/* Pull PWR_ENn low.*/
+			gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ,
+						  GPIO_CNF_OUTPUT_OPENDRAIN, GPIO15);
+			gpio_clear(GPIOB, GPIO15);
+			/* Pull USB_RENUM low!*/
+			gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
+						  GPIO_CNF_OUTPUT_OPENDRAIN, GPIO15);
+			gpio_clear(GPIOA, GPIO15);
+		} else
+			/* Catch F4 Disco board with both resistors fitted.*/
+			rev = 1;
+		/* On Rev > 0 unconditionally activate MCO on PORTA8 with HSE! */
+		RCC_CFGR &= ~(0xf << 24);
+		RCC_CFGR |= (RCC_CFGR_MCO_HSE << 24);
+		gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
+		GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO8);
+	}
+	if (rev < 2) {
+		gpio_clear(GPIOA, GPIO12);
+		gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
+					  GPIO_CNF_OUTPUT_OPENDRAIN, GPIO12);
+	}
+	return rev;
+}
+
+void platform_request_boot(void)
+{
+	uint32_t crl = GPIOA_CRL;
+	/* Assert bootloader marker.
+	 * Enable Pull on GPIOA1. We don't rely on the external pin
+	 * really pulled, but only on the value of the CNF register
+	 * changed from the reset value
+	 */
+	crl &= 0xffffff0f;
+	crl |= 0x80;
+	GPIOA_CRL = crl;
+	SCB_VTOR = 0;
+}

--- a/src/platforms/stlink-ud/swdptap.c
+++ b/src/platforms/stlink-ud/swdptap.c
@@ -1,0 +1,243 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* This file implements the SW-DP interface. */
+
+#include "general.h"
+#include "swdptap.h"
+
+#define SWD_XDELAY 0
+#define SWD_XDELAY2 0
+
+volatile int	swd_counter;
+#ifdef SWD_XDELAY
+void swd_xdelay(void)
+{
+    for (swd_counter = 0; swd_counter < SWD_XDELAY; swd_counter++)
+        ;
+}
+void swd_xdelay2(void)
+{
+    for (swd_counter = 0; swd_counter < SWD_XDELAY2; swd_counter++)
+        ;
+}
+#else
+#define swd_xdelay()
+#define swd_xdelay2()
+#endif
+
+enum {
+	SWDIO_STATUS_FLOAT = 0,
+	SWDIO_STATUS_DRIVE
+};
+
+int swdptap_init(void)
+{
+	return 0;
+}
+
+static void swdptap_turnaround(int dir)
+{
+	static int olddir = SWDIO_STATUS_FLOAT;
+
+	/* Don't turnaround if direction not changing */
+	if(dir == olddir) return;
+	olddir = dir;
+
+#ifdef DEBUG_SWD_BITS
+	DEBUG("%s", dir ? "\n-> ":"\n<- ");
+#endif
+
+	if(dir == SWDIO_STATUS_FLOAT) {
+            gpio_set(SWDDIR_PORT, SWDDIR_PIN);
+            SWDIO_MODE_FLOAT_Z();
+        }
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+	if(dir == SWDIO_STATUS_DRIVE) {
+            gpio_clear(SWDDIR_PORT, SWDDIR_PIN);
+#if 0
+            SWDIO_MODE_DRIVE();
+#endif
+        }
+        swd_xdelay2();
+}
+
+bool swdptap_bit_in(void)
+{
+	uint16_t ret;
+
+	swdptap_turnaround(SWDIO_STATUS_FLOAT);
+
+        swd_xdelay();
+	ret = gpio_get(SWDIO_PORT, SWDIO_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+
+#ifdef DEBUG_SWD_BITS
+	DEBUG("%d", ret?1:0);
+#endif
+
+	return ret != 0;
+}
+
+uint32_t
+swdptap_seq_in(int ticks)
+{
+	uint32_t index = 1;
+	uint32_t ret = 0;
+	int len = ticks;
+
+	swdptap_turnaround(SWDIO_STATUS_FLOAT);
+	while (len--) {
+		int res;
+                swd_xdelay();
+		res = gpio_get(SWDIO_PORT, SWDIO_PIN);
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+                swd_xdelay();
+		if (res)
+			ret |= index;
+		index <<= 1;
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	}
+        swd_xdelay();
+
+#ifdef DEBUG_SWD_BITS
+	for (int i = 0; i < len; i++)
+		DEBUG("%d", (ret & (1 << i)) ? 1 : 0);
+#endif
+	return ret;
+}
+
+bool
+swdptap_seq_in_parity(uint32_t *ret, int ticks)
+{
+	uint32_t index = 1;
+	uint8_t parity = 0;
+	uint32_t res = 0;
+	bool bit;
+	int len = ticks;
+
+	swdptap_turnaround(SWDIO_STATUS_FLOAT);
+	while (len--) {
+		bit = gpio_get(SWDIO_PORT, SWDIO_PIN);
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+                swd_xdelay();
+		if (bit) {
+			res |= index;
+			parity ^= 1;
+		}
+		index <<= 1;
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
+                swd_xdelay();
+	}
+	bit = gpio_get(SWDIO_PORT, SWDIO_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+	if (bit)
+		parity ^= 1;
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+#ifdef DEBUG_SWD_BITS
+	for (int i = 0; i < len; i++)
+		DEBUG("%d", (res & (1 << i)) ? 1 : 0);
+#endif
+	*ret = res;
+	return parity;
+}
+
+void swdptap_bit_out(bool val)
+{
+#ifdef DEBUG_SWD_BITS
+	DEBUG("%d", val);
+#endif
+
+	swdptap_turnaround(SWDIO_STATUS_DRIVE);
+
+	gpio_set_val(SWDOUT_PORT, SWDOUT_PIN, val);
+        swd_xdelay();
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+}
+void
+swdptap_seq_out(uint32_t MS, int ticks)
+{
+	int data = MS & 1;
+#ifdef DEBUG_SWD_BITS
+	for (int i = 0; i < ticks; i++)
+		DEBUG("%d", (MS & (1 << i)) ? 1 : 0);
+#endif
+	swdptap_turnaround(SWDIO_STATUS_DRIVE);
+	while (ticks--) {
+		gpio_set_val(SWDOUT_PORT, SWDOUT_PIN, data);
+                swd_xdelay();
+		MS >>= 1;
+		data = MS & 1;
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+                swd_xdelay();
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	}
+        swd_xdelay();
+}
+
+void
+swdptap_seq_out_parity(uint32_t MS, int ticks)
+{
+	uint8_t parity = 0;
+	int data = MS & 1;
+#ifdef DEBUG_SWD_BITS
+	for (int i = 0; i < ticks; i++)
+		DEBUG("%d", (MS & (1 << i)) ? 1 : 0);
+#endif
+	swdptap_turnaround(SWDIO_STATUS_DRIVE);
+
+	while (ticks--) {
+		gpio_set_val(SWDOUT_PORT, SWDOUT_PIN, data);
+                swd_xdelay();
+		parity ^= MS;
+		MS >>= 1;
+		gpio_set(SWCLK_PORT, SWCLK_PIN);
+                swd_xdelay();
+		data = MS & 1;
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	}
+        swd_xdelay();
+	gpio_set_val(SWDOUT_PORT, SWDOUT_PIN, parity & 1);
+        swd_xdelay();
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	gpio_set(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+        swd_xdelay();
+}

--- a/src/platforms/stlink-ud/usbdfu.c
+++ b/src/platforms/stlink-ud/usbdfu.c
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2013 Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+#include <libopencm3/cm3/systick.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/cm3/scb.h>
+
+#include "usbdfu.h"
+#include "general.h"
+#include "platform.h"
+
+static uint32_t rev;
+static uint16_t led_bootloader;
+static uint16_t pin_nrst;
+static uint32_t led2_state = 0;
+
+uint32_t app_address = 0x08002000;
+
+static bool stlink_test_nrst(void)
+{
+	uint16_t nrst;
+	gpio_set_mode(GPIOB, GPIO_MODE_INPUT,
+	              GPIO_CNF_INPUT_PULL_UPDOWN, pin_nrst);
+	gpio_set(GPIOB, pin_nrst);
+	for (int i = 0; i < 10000; i++)
+		nrst = gpio_get(GPIOB, pin_nrst);
+	return (nrst) ? true : false;
+}
+
+void dfu_detach(void)
+{
+	scb_reset_system();
+}
+
+int main(void)
+{
+	rev = detect_rev();
+	if (rev == 0) {
+		led_bootloader = GPIO8;
+		pin_nrst = GPIO1;
+	} else {
+		led_bootloader = GPIO9;
+		pin_nrst = GPIO0;
+	}
+
+	if(((GPIOA_CRL & 0x40) == 0x40) && stlink_test_nrst())
+		dfu_jump_app_if_valid();
+	dfu_protect(DFU_MODE);
+
+	rcc_clock_setup_in_hse_8mhz_out_72mhz();
+	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB_DIV8);
+	systick_set_reload(900000);
+
+
+	systick_interrupt_enable();
+	systick_counter_enable();
+
+	if (rev > 1)
+		gpio_set(GPIOA, GPIO15);
+	dfu_init(&st_usbfs_v1_usb_driver, DFU_MODE);
+
+	dfu_main();
+}
+
+void dfu_event(void)
+{
+}
+
+void sys_tick_handler(void)
+{
+	if (rev == 0) {
+		gpio_toggle(GPIOA, led_bootloader);
+	} else {
+		if (led2_state & 1) {
+			gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
+				GPIO_CNF_OUTPUT_PUSHPULL, led_bootloader);
+			gpio_clear(GPIOA, led_bootloader);
+		} else {
+			gpio_set_mode(GPIOA, GPIO_MODE_INPUT,
+				GPIO_CNF_INPUT_ANALOG, led_bootloader);
+		}
+		led2_state++;
+	}
+}


### PR DESCRIPTION
I implemented an stlink variant named stlink-ud, which can be used with unidirectional digital isolators or level translators.  This is useful to flash or debug eg. 5 volt targets or targets in a different supply voltage domain.  Just compile with make PROBE_HOST=stlink-ud .  This pull request only add a directory  src/platforms/stlink-ud and doesn't touch anything else.

I will provide a suitable schematics later.