### PR TITLE
Native: Link against nanolib.

### DIFF
--- a/src/platforms/native/Makefile.inc
+++ b/src/platforms/native/Makefile.inc
@@ -6,7 +6,8 @@ CFLAGS += -Istm32/include -mcpu=cortex-m3 -mthumb \
 	-DSTM32F1 -DBLACKMAGIC -I../libopencm3/include \
 	-Iplatforms/stm32
 
-LDFLAGS_BOOT := $(LDFLAGS) -lopencm3_stm32f1 -Wl,--defsym,_stack=0x20005000 \
+LDFLAGS_BOOT := $(LDFLAGS) --specs=nano.specs \
+	-lopencm3_stm32f1 -Wl,--defsym,_stack=0x20005000 \
 	-Wl,-T,platforms/stm32/blackmagic.ld -nostartfiles -lc \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m3 -Wl,-gc-sections \
 	-L../libopencm3/lib


### PR DESCRIPTION
This frees about 13 kB or 30 kB with ENABLE_DEBUG=1