### PR TITLE
Target: Default to nop-function() for all exported target functions.

### DIFF
--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -352,11 +352,6 @@ const struct command_s kinetis_mdm_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static bool nop_function(void)
-{
-	return true;
-}
-
 enum target_halt_reason mdm_halt_poll(target *t, target_addr *watch)
 {
 	(void)t; (void)watch;
@@ -383,19 +378,7 @@ void kinetis_mdm_probe(ADIv5_AP_t *ap)
 	t->priv_free = (void*)adiv5_ap_unref;
 
 	t->driver = "Kinetis Recovery (MDM-AP)";
-	t->attach = (void*)nop_function;
-	t->detach = (void*)nop_function;
-	t->check_error = (void*)nop_function;
-	t->mem_read = (void*)nop_function;
-	t->mem_write = (void*)nop_function;
 	t->regs_size = 4;
-	t->regs_read = (void*)nop_function;
-	t->regs_write = (void*)nop_function;
-	t->reset = (void*)nop_function;
-	t->halt_request = (void*)nop_function;
-	t->halt_poll = mdm_halt_poll;
-	t->halt_resume = (void*)nop_function;
-
 	target_add_commands(t, kinetis_mdm_cmd_list, t->driver);
 }
 

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -360,11 +360,6 @@ const struct command_s nrf51_mdm_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static bool nop_function(void)
-{
-	return true;
-}
-
 void nrf51_mdm_probe(ADIv5_AP_t *ap)
 {
 	switch(ap->idr) {
@@ -384,20 +379,7 @@ void nrf51_mdm_probe(ADIv5_AP_t *ap)
 	t->priv_free = (void*)adiv5_ap_unref;
 
 	t->driver = "Nordic nRF52 Access Port";
-	t->attach = (void*)nop_function;
-	t->detach = (void*)nop_function;
-	t->check_error = (void*)nop_function;
-	t->mem_read = (void*)nop_function;
-	t->mem_write = (void*)nop_function;
 	t->regs_size = 4;
-	t->regs_read = (void*)nop_function;
-	t->regs_write = (void*)nop_function;
-	t->reset = (void*)nop_function;
-	t->halt_request = (void*)nop_function;
-	//t->halt_poll = mdm_halt_poll;
-	t->halt_poll = (void*)nop_function;
-	t->halt_resume = (void*)nop_function;
-
 	target_add_commands(t, nrf51_mdm_cmd_list, t->driver);
 }
 

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -30,6 +30,11 @@ static int target_flash_write_buffered(struct target_flash *f,
                                        target_addr dest, const void *src, size_t len);
 static int target_flash_done_buffered(struct target_flash *f);
 
+static bool nop_function(void)
+{
+	return true;
+}
+
 target *target_new(void)
 {
 	target *t = (void*)calloc(1, sizeof(*t));
@@ -46,6 +51,20 @@ target *target_new(void)
 	} else {
 		target_list = t;
 	}
+
+	t->attach = (void*)nop_function;
+	t->detach = (void*)nop_function;
+	t->check_error = (void*)nop_function;
+	t->mem_read = (void*)nop_function;
+	t->mem_write = (void*)nop_function;
+	t->reg_read = (void*)nop_function;
+	t->reg_write = (void*)nop_function;
+	t->regs_read = (void*)nop_function;
+	t->regs_write = (void*)nop_function;
+	t->reset = (void*)nop_function;
+	t->halt_request = (void*)nop_function;
+	t->halt_poll = (void*)nop_function;
+	t->halt_resume = (void*)nop_function;
 
 	return t;
 }


### PR DESCRIPTION
Fixes #522.