### PR TITLE
Add support for LPC1114/333 (LPC1100XL series)

### DIFF
--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -147,6 +147,7 @@ lpc11xx_probe(target *t)
 		target_add_ram(t, 0x10000000, 0x2000);
 		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000);
 		return true;
+	case 0x00040070:	/* LPC1114/333 */
 	case 0x00050080:	/* lpc1115XL */
 		t->driver = "LPC1100XL";
 		target_add_ram(t, 0x10000000, 0x2000);


### PR DESCRIPTION
... and add support for LPC1114/333 (LPC1100XL series), similar to how it was done for the LPC17xx. This series requires making an IAP call to determine the part ID, it seems that there is no other way.

I've tested this PR on an LPC1114/333 and it detects it, ~~and the PR doesn't alter any existing code paths so there should be no regressions~~; I did a test with an LPC1114FN28 and it seems all good. We can now easily add other LPC1100XL devices in the new switch statement. But we need to check that the IAP call can be made safely or it might break other devices (see comments below).

One other question I have with this PR is that I had to save the target registers prior to the IAP call and then restore them afterwards before resuming otherwise the IAP call corrupts the program state. But I don't see the registers being saved and restored in the LPC17xx code. Can anyone shed some light on this? Does the target actually resume properly with an LPC17xx during detection, is there some difference? Thanks.