### PR TITLE
Fix buffer overflow in adiv5_component_probe()

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -263,7 +263,7 @@ static bool adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, int recursion, 
 	uint32_t cidr = 0;
 	bool res = false;
 #if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
-	char indent[recursion];
+	char indent[recursion + 1];
 
 	for(int i = 0; i < recursion; i++) indent[i] = ' ';
 	indent[recursion] = 0;


### PR DESCRIPTION
This shows up when printing the ROM table to the debug console as garbage characters before indented table entries. The buffer holding the spaces used for the indent is one byte too short. 