### PR TITLE
BUGFIX: tokenization of gdb monitor commands

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -94,8 +94,9 @@ long cortexm_wait_timeout = 2000; /* Timeout to wait for Cortex to react on halt
 int command_process(target *t, char *cmd)
 {
 	const struct command_s *c;
-	int argc = 0;
+	int argc = 1;
 	const char **argv;
+	const char *part;
 
 	/* Initial estimate for argc */
 	for(char *s = cmd; *s; s++)
@@ -104,8 +105,9 @@ int command_process(target *t, char *cmd)
 	argv = alloca(sizeof(const char *) * argc);
 
 	/* Tokenize cmd to find argv */
-	for(argc = 0, argv[argc] = strtok(cmd, " \t");
-		argv[argc]; argv[++argc] = strtok(NULL, " \t"));
+	argc = 0;
+	for (part = strtok(cmd, " \t"); part; part = strtok(NULL, " \t"))
+		argv[argc++] = part;
 
 	/* Look for match and call handler */
 	for(c = cmd_list; c->cmd; c++) {


### PR DESCRIPTION
I had issues with the `mon jtag_scan <ir_list>` feature, and discovered, that the GDB monitor command parsing is buggy.

* The *estimated* argv count was wrong
* The tokenizing loop probably triggered some sort of UB, I do not really understand it. My version does not cause issues with libc stack protectors and -fsanitize=address

**How to reproduce:**

Compile PROBE_HOST=pc-hosted with a recent version of GCC (I used 9.2), and
add `-fsanitize=address` to *C_FLAGS* and *LD_FLAGS*.