### PR TITLE
Support NXP LPC1343

### DIFF
--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -97,6 +97,12 @@ lpc11xx_probe(target *t)
 		target_add_ram(t, 0x10000000, 0x1000);
 		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x1000);
 		return true;
+	case 0x3000002B:
+	case 0x3D00002B:
+		t->driver = "LPC1343";
+		target_add_ram(t, 0x10000000, 0x2000);
+		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x1000);
+		return true;
 	}
 
 	idcode = target_mem_read32(t, LPC8XX_DEVICE_ID);


### PR DESCRIPTION
Tested on real hardware, works fine. 

```Debug mode is enabled
Target voltage: unknown
Available Targets:
No. Att Driver
 1      LPC1343 M3/M4
0x0000029e in read_adc_naiive (channel=0 '\000') at main.c:96
96		while (!adc_eoc(ADC1));
Loading section .text, size 0x3c90 lma 0x0
Loading section .data, size 0x1e0 lma 0x3c90
Start address 0x7dc, load size 15984
Transfer rate: 22 KB/sec, 940 bytes/write.
Kill the program being debugged? (y or n) [answered Y; input not from terminal]
```