### PR TITLE
Clearer handling of the baudrate parameter of the traceswo command

### DIFF
--- a/src/platforms/common/traceswo.h
+++ b/src/platforms/common/traceswo.h
@@ -22,7 +22,12 @@
 
 #include <libopencm3/usb/usbd.h>
 
+#if defined TRACESWO_PROTOCOL && TRACESWO_PROTOCOL == 2
 void traceswo_init(uint32_t baudrate);
+#else
+void traceswo_init(void);
+#endif
+
 void trace_buf_drain(usbd_device *dev, uint8_t ep);
 
 #endif

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -70,6 +70,7 @@
 
 #define PLATFORM_HAS_TRACESWO	1
 #define NUM_TRACE_PACKETS		(128)		/* This is an 8K buffer */
+#define TRACESWO_PROTOCOL		2			/* 1 = Manchester, 2 = NRZ / async */
 
 # define SWD_CR   GPIO_CRH(SWDIO_PORT)
 # define SWD_CR_MULT (1 << ((14 - 8) << 2))

--- a/src/platforms/stm32/traceswo.c
+++ b/src/platforms/stm32/traceswo.c
@@ -33,6 +33,7 @@
  */
 #include "general.h"
 #include "cdcacm.h"
+#include "traceswo.h"
 
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/timer.h>

--- a/src/platforms/stm32/traceswoasync.c
+++ b/src/platforms/stm32/traceswoasync.c
@@ -30,7 +30,7 @@
 
 #include "general.h"
 #include "cdcacm.h"
-#include "platform.h"
+#include "traceswo.h"
 
 #include <libopencmsis/core_cm3.h>
 #include <libopencm3/cm3/nvic.h>

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -64,6 +64,7 @@
 
 #define PLATFORM_HAS_TRACESWO	1
 #define NUM_TRACE_PACKETS		(128)		/* This is an 8K buffer */
+#define TRACESWO_PROTOCOL		2			/* 1 = Manchester, 2 = NRZ / async */
 
 # define SWD_CR   GPIO_CRH(SWDIO_PORT)
 # define SWD_CR_MULT (1 << ((13 - 8) << 2))


### PR DESCRIPTION
Make baudrate parameter of traceswo command mandatory for stlink/swlink, and superfluous on other platforms; change help message accordingly.