### PR TITLE
Fix SAMx5x build failure - MinGW - Windows

### DIFF
--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -31,6 +31,8 @@
  * particularly Sections 12. DSU and 25. NVMCTRL
  */
 
+#define __USE_MINGW_ANSI_STDIO 1
+
 #include <ctype.h>
 
 #include "general.h"


### PR DESCRIPTION
The format specifier "z" causes a build failure for the SAMx5x target MCU. This happens when pc-stlinkv2 is built.

Please test and comment.