### PR TITLE
Wait after reset (fixes #573)

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -213,6 +213,7 @@ void wait_for_srst(void)
 	while (platform_srst_get_val() && !platform_timeout_is_expired(&timeout));
 
 	if (platform_timeout_is_expired(&timeout)) {
+		DEBUG("Timeout waiting for SRST to go high\n");
 	} else {
 		/* Wait for the same duration again as the high/low
 		   thresholds of the BMP and the target might not match.

--- a/src/platforms/stm32/timing_stm32.c
+++ b/src/platforms/stm32/timing_stm32.c
@@ -23,13 +23,14 @@
 #include <libopencm3/cm3/scb.h>
 
 uint8_t running_status;
+uint8_t led_update_counter;
 static volatile uint32_t time_ms;
 
 void platform_timing_init(void)
 {
 	/* Setup heartbeat timer */
 	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB_DIV8);
-	systick_set_reload(900000);	/* Interrupt us at 10 Hz */
+	systick_set_reload(9000);	/* Interrupt us at 1000 Hz */
 	SCB_SHPR(11) &= ~((15 << 4) & 0xff);
 	SCB_SHPR(11) |= ((14 << 4) & 0xff);
 	systick_interrupt_enable();
@@ -45,12 +46,16 @@ void platform_delay(uint32_t ms)
 
 void sys_tick_handler(void)
 {
-	if(running_status)
-		gpio_toggle(LED_PORT, LED_IDLE_RUN);
+	time_ms++;
+	led_update_counter++;
+	if (led_update_counter == 100) {
+		led_update_counter = 0;
 
-	time_ms += 100;
+		if(running_status)
+			gpio_toggle(LED_PORT, LED_IDLE_RUN);
 
-	SET_ERROR_STATE(morse_update());
+		SET_ERROR_STATE(morse_update());
+	}
 }
 
 uint32_t platform_time_ms(void)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -601,6 +601,12 @@ static void cortexm_reset(target *t)
 	if ((t->target_options & CORTEXM_TOPT_INHIBIT_SRST) == 0) {
 		platform_srst_set_val(true);
 		platform_srst_set_val(false);
+
+		/* Wait for 1ms as the reset takes a long time to
+		 * return to high state on certain boards,
+		 * and the MCU is not working during that time.
+		 */ 
+		platform_delay(1);
 	}
 
 	/* Read DHCSR here to clear S_RESET_ST bit before reset */

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -601,16 +601,13 @@ static void cortexm_reset(target *t)
 	if ((t->target_options & CORTEXM_TOPT_INHIBIT_SRST) == 0) {
 		platform_srst_set_val(true);
 		platform_srst_set_val(false);
-
-		/* Wait for 1ms as the reset takes a long time to
-		 * return to high state on certain boards,
-		 * and the MCU is not working during that time.
-		 */ 
-		platform_delay(1);
 	}
 
 	/* Read DHCSR here to clear S_RESET_ST bit before reset */
 	target_mem_read32(t, CORTEXM_DHCSR);
+	if (target_check_error(t)) {
+		DEBUG("Reading CORTEXM_DHCSR failed\n");
+	}
 
 	/* Request system reset from NVIC: SRST doesn't work correctly */
 	/* This could be VECTRESET: 0x05FA0001 (reset only core)


### PR DESCRIPTION
Fix for #573 

On the Arduino Nano 33 BLE, the reset signal takes a long time to return to the high state. During that time the MCU is stopped and all memory operations in cortexm_reset() fail. So wait for 1ms after toggling SRST.