### PR TITLE
Handle slow reset

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -179,7 +179,7 @@ static bool cmd_jtag_scan(target *t, int argc, char **argv)
 	}
 
 	if(connect_assert_srst)
-		platform_srst_set_val(true); /* will be deasserted after attach */
+		platform_srst_assert(); /* will be deasserted after attach */
 
 	int devs = -1;
 	volatile struct exception e;
@@ -196,7 +196,7 @@ static bool cmd_jtag_scan(target *t, int argc, char **argv)
 	}
 
 	if(devs <= 0) {
-		platform_srst_set_val(false);
+		platform_srst_release();
 		gdb_out("JTAG device scan failed!\n");
 		return false;
 	}
@@ -213,7 +213,7 @@ bool cmd_swdp_scan(target *t, int argc, char **argv)
 	gdb_outf("Target voltage: %s\n", platform_target_voltage());
 
 	if(connect_assert_srst)
-		platform_srst_set_val(true); /* will be deasserted after attach */
+		platform_srst_assert(); /* will be deasserted after attach */
 
 	int devs = -1;
 	volatile struct exception e;
@@ -230,7 +230,7 @@ bool cmd_swdp_scan(target *t, int argc, char **argv)
 	}
 
 	if(devs <= 0) {
-		platform_srst_set_val(false);
+		platform_srst_release();
 		gdb_out("SW-DP scan failed!\n");
 		return false;
 	}
@@ -327,8 +327,7 @@ static bool cmd_hard_srst(target *t, int argc, const char **argv)
 	(void)argc;
 	(void)argv;
 	target_list_free();
-	platform_srst_set_val(true);
-	platform_srst_set_val(false);
+	platform_srst_reset();
 	return true;
 }
 

--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -39,6 +39,22 @@ const char *platform_target_voltage(void);
 int platform_hwversion(void);
 void platform_srst_set_val(bool assert);
 bool platform_srst_get_val(void);
+
+/**
+ * @brief Perform a hard SRST reset (incl. necessary waiting).
+ */
+void platform_srst_reset();
+
+/**
+ * @brief Assert SRST for at least 1ms.
+ */
+void platform_srst_assert(void);
+
+/**
+ * @brief Release SRST and wait until the SRST level has fully recovered.
+ */
+void platform_srst_release(void);
+
 bool platform_target_get_power(void);
 void platform_target_set_power(bool power);
 void platform_request_boot(void);

--- a/src/platforms/common/srst.c
+++ b/src/platforms/common/srst.c
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2019  Black Sphere Technologies Ltd.
+ * Written by Manuel Bleichenbacher <manuel.bleichenbacher@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This file implements the platform agnostic functions for handling the SRST.
+ */
+
+#include "general.h"
+#include "platform_support.h"
+
+void platform_srst_reset()
+{
+    platform_srst_assert();
+    platform_srst_release();
+}
+
+void platform_srst_assert(void)
+{
+    platform_srst_set_val(true);
+    /* Hold reset for 1ms */
+    platform_delay(1);
+}
+
+void platform_srst_release(void)
+{
+    platform_srst_set_val(false);
+
+	/* Wait for SRST to go high
+	   but no longer than 200ms */
+	uint32_t start = platform_time_ms();
+	platform_timeout timeout;
+	platform_timeout_set(&timeout, 200);
+	while (platform_srst_get_val() && !platform_timeout_is_expired(&timeout));
+
+	if (platform_timeout_is_expired(&timeout)) {
+        DEBUG("Timeout waiting for SRST to be released\n");
+	} else {
+        /* The high/low thresholds of the BMP and the target might differ and
+            the target will need some time to become responsive after reset.
+            So wait the same time again. Wait time is increased by 1ms as
+            a delay of up to 999us can be reported as 0 due to the timer
+            resolution. */
+		platform_delay(platform_time_ms() - start + 1);
+	}
+}

--- a/src/platforms/f4discovery/Makefile.inc
+++ b/src/platforms/f4discovery/Makefile.inc
@@ -19,6 +19,7 @@ SRC += 	cdcacm.c	\
 	traceswo.c	\
 	usbuart.c	\
 	serialno.c	\
+	srst.c	\
 	timing.c	\
 	timing_stm32.c	\
 

--- a/src/platforms/hydrabus/Makefile.inc
+++ b/src/platforms/hydrabus/Makefile.inc
@@ -19,6 +19,7 @@ SRC += 	cdcacm.c	\
 	traceswo.c	\
 	usbuart.c	\
 	serialno.c	\
+	srst.c	\
 	timing.c	\
 	timing_stm32.c	\
 

--- a/src/platforms/launchpad-icdi/Makefile.inc
+++ b/src/platforms/launchpad-icdi/Makefile.inc
@@ -15,6 +15,7 @@ VPATH += platforms/tm4c
 
 SRC +=	cdcacm.c	\
 	usbuart.c	\
+	srst.c        \
 	timing.c        \
 	traceswo.o
 

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -97,10 +97,8 @@ platform_init(void)
 
 void platform_srst_set_val(bool assert)
 {
-	volatile int i;
 	if (assert) {
 		gpio_clear(SRST_PORT, SRST_PIN);
-		for(i = 0; i < 10000; i++) asm("nop");
 	} else {
 		gpio_set(SRST_PORT, SRST_PIN);
 	}

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -25,7 +25,7 @@
 #include <libopencm3/cm3/systick.h>
 #include <libopencm3/lm4f/usb.h>
 
-#define SYSTICKHZ	100
+#define SYSTICKHZ	1000
 #define SYSTICKMS	(1000 / SYSTICKHZ)
 
 #define PLL_DIV_80MHZ	5
@@ -35,12 +35,17 @@ extern void trace_tick(void);
 
 volatile platform_timeout * volatile head_timeout;
 uint8_t running_status;
+uint8_t trace_counter;
 static volatile uint32_t time_ms;
 
 void sys_tick_handler(void)
 {
-	trace_tick();
-	time_ms += 10;
+	trace_counter++;
+	if (trace_counter == 10) {
+		trace_counter = 0;
+		trace_tick();
+	}
+	time_ms++;
 }
 
 uint32_t platform_time_ms(void)

--- a/src/platforms/libftdi/Makefile.inc
+++ b/src/platforms/libftdi/Makefile.inc
@@ -8,5 +8,5 @@ else ifneq (, $(findstring cygwin, $(SYS)))
 LDFLAGS +=  -lusb-1.0 -lws2_32
 endif
 VPATH += platforms/pc
-SRC += 	timing.c cl_utils.c
+SRC += 	srst.c timing.c cl_utils.c
 CFLAGS +=-I ./target -I./platforms/pc

--- a/src/platforms/native/Makefile.inc
+++ b/src/platforms/native/Makefile.inc
@@ -24,6 +24,7 @@ SRC += 	cdcacm.c	\
 	traceswo.c	\
 	usbuart.c	\
 	serialno.c	\
+	srst.c	\
 	timing.c	\
 	timing_stm32.c	\
 

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -189,9 +189,6 @@ void platform_srst_set_val(bool assert)
 	} else {
 		gpio_set_val(SRST_PORT, SRST_PIN, !assert);
 	}
-	if (assert) {
-		for(int i = 0; i < 10000; i++) asm("nop");
-	}
 }
 
 bool platform_srst_get_val(void)

--- a/src/platforms/pc-hosted/Makefile.inc
+++ b/src/platforms/pc-hosted/Makefile.inc
@@ -11,4 +11,4 @@ else ifneq (, $(findstring cygwin, $(SYS)))
 LDFLAGS +=  -lusb-1.0 -lws2_32
 endif
 VPATH += platforms/pc
-SRC += 	cl_utils.c timing.c
+SRC += 	cl_utils.c srst.c timing.c

--- a/src/platforms/pc-stlinkv2/Makefile.inc
+++ b/src/platforms/pc-stlinkv2/Makefile.inc
@@ -9,5 +9,5 @@ else ifneq (, $(findstring cygwin, $(SYS)))
 LDFLAGS += -lws2_32
 endif
 VPATH += platforms/pc
-SRC += 	timing.c stlinkv2.c cl_utils.c
+SRC += 	srst.c timing.c stlinkv2.c cl_utils.c
 OWN_HL = 1

--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -30,6 +30,7 @@ VPATH += platforms/stm32
 SRC += 	cdcacm.c	\
 	usbuart.c 	\
 	serialno.c	\
+	srst.c	\
 	timing.c	\
 	timing_stm32.c	\
 	traceswoasync.c	\

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -93,12 +93,10 @@ void platform_srst_set_val(bool assert)
 		gpio_set_mode(SRST_PORT, GPIO_MODE_OUTPUT_50_MHZ,
 		              GPIO_CNF_OUTPUT_OPENDRAIN, srst_pin);
 		gpio_clear(SRST_PORT, srst_pin);
-		while (gpio_get(SRST_PORT, srst_pin)) {};
 	} else {
 		gpio_set_mode(SRST_PORT, GPIO_MODE_INPUT,
 			GPIO_CNF_INPUT_PULL_UPDOWN, srst_pin);
 		gpio_set(SRST_PORT, srst_pin);
-		while (!gpio_get(SRST_PORT, srst_pin)) {};
 	}
 }
 

--- a/src/platforms/stm32/timing_stm32.c
+++ b/src/platforms/stm32/timing_stm32.c
@@ -23,13 +23,14 @@
 #include <libopencm3/cm3/scb.h>
 
 uint8_t running_status;
+uint8_t led_update_counter;
 static volatile uint32_t time_ms;
 
 void platform_timing_init(void)
 {
 	/* Setup heartbeat timer */
 	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB_DIV8);
-	systick_set_reload(900000);	/* Interrupt us at 10 Hz */
+	systick_set_reload(9000);	/* Interrupt us at 1000 Hz */
 	SCB_SHPR(11) &= ~((15 << 4) & 0xff);
 	SCB_SHPR(11) |= ((14 << 4) & 0xff);
 	systick_interrupt_enable();
@@ -45,12 +46,16 @@ void platform_delay(uint32_t ms)
 
 void sys_tick_handler(void)
 {
-	if(running_status)
-		gpio_toggle(LED_PORT, LED_IDLE_RUN);
+	time_ms++;
+	led_update_counter++;
+	if (led_update_counter == 100) {
+		led_update_counter = 0;
 
-	time_ms += 100;
+		if(running_status)
+			gpio_toggle(LED_PORT, LED_IDLE_RUN);
 
-	SET_ERROR_STATE(morse_update());
+		SET_ERROR_STATE(morse_update());
+	}
 }
 
 uint32_t platform_time_ms(void)

--- a/src/platforms/swlink/Makefile.inc
+++ b/src/platforms/swlink/Makefile.inc
@@ -23,6 +23,7 @@ VPATH += platforms/stm32
 SRC += 	cdcacm.c	\
 	usbuart.c 	\
 	serialno.c	\
+	srst.c	\
 	timing.c	\
 	timing_stm32.c	\
 	traceswoasync.c	\

--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -120,15 +120,11 @@ void platform_srst_set_val(bool assert)
 	if (assert) {
 		gpio_set_mode(JRST_PORT, GPIO_MODE_OUTPUT_50_MHZ,
 		              GPIO_CNF_OUTPUT_OPENDRAIN, JRST_PIN);
-		/* Wait until requested value is active.*/
-		while (gpio_get(JRST_PORT, JRST_PIN))
-			gpio_clear(JRST_PORT, JRST_PIN);
+		gpio_clear(JRST_PORT, JRST_PIN);
 	} else {
 		gpio_set_mode(JRST_PORT, GPIO_MODE_INPUT,
 					  GPIO_CNF_INPUT_PULL_UPDOWN, JRST_PIN);
-		/* Wait until requested value is active.*/
-		while (!gpio_get(JRST_PORT, JRST_PIN))
-			gpio_set(JRST_PORT, JRST_PIN);
+		gpio_set(JRST_PORT, JRST_PIN);
 	}
 }
 

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -404,7 +404,7 @@ bool cortexa_attach(target *t)
 	priv->hw_breakpoint_mask = 0;
 	priv->bcr0 = 0;
 
-	platform_srst_set_val(false);
+	platform_srst_release();
 
 	return true;
 }
@@ -575,8 +575,7 @@ static void cortexa_reset(target *t)
 	target_mem_write32(t, ZYNQ_SLCR_PSS_RST_CTRL, 1);
 
 	/* Try hard reset too */
-	platform_srst_set_val(true);
-	platform_srst_set_val(false);
+	platform_srst_reset();
 
 	/* Spin until Xilinx reconnects us */
 	platform_timeout timeout;


### PR DESCRIPTION
New pull request replacing #574. Fix for #573. 

On the Arduino Nano 33 BLE, the reset signal takes a long time to return to the high state. During that time the MCU is stopped and all memory operations in `cortexm_reset()` fail.

This pull request is the result of discussions with @UweBonnes:

- New functions (platform agnostic):
    - `platform_srst_assert`: assert SRST for 1ms
    - `platform_srst_release`: release SRST and wait until the target is likely responsive again
    - `platform_srst_reset`: perform reset (assert & release)
- Replace the low-level functions with the new ones where appropriate
- Improve timing functions (timeouts, time measurement, delay) to a minimum precision of 1ms (relevant for STM32-based hosts and Launchpad ICDI)
- Removed timing and read-back code from `platform_srst_get_val()` as it has been moved to the new platform agnostic functions 

Aside from the cleanup, the main addition is `platform_srst_reset`. After releasing SRST, it waits until reading back the GPIO value shows the desired effect and measures the duration. It then waits the same duration again as the target might have different thresholds to distinguish low/high and as the target might need a short time to become responsive again.

This should solve the problem observed on the Arduino Nano BLE 33, which is not immediately responsive after the reset signal is released since it takes about 1ms to return to the high level.