### PR TITLE
Remove MCU specific include path from traceswo and traceswoasync files

### DIFF
--- a/src/platforms/stm32/dfu_f1.c
+++ b/src/platforms/stm32/dfu_f1.c
@@ -19,7 +19,7 @@
 #include "general.h"
 #include "usbdfu.h"
 
-#include <libopencm3/stm32/f1/flash.h>
+#include <libopencm3/stm32/flash.h>
 #include <libopencm3/cm3/scb.h>
 
 #define FLASH_OBP_RDP 0x1FFFF800

--- a/src/platforms/stm32/dfu_f4.c
+++ b/src/platforms/stm32/dfu_f4.c
@@ -19,11 +19,8 @@
 #include "general.h"
 #include "usbdfu.h"
 
-#if defined(STM32F2)
-#	include <libopencm3/stm32/f2/flash.h>
-#elif defined(STM32F4)
-#	include <libopencm3/stm32/f4/flash.h>
-#endif
+#include <libopencm3/stm32/flash.h>
+
 #include <libopencm3/cm3/scb.h>
 
 static uint32_t sector_addr[] = {

--- a/src/platforms/stm32/dfucore.c
+++ b/src/platforms/stm32/dfucore.c
@@ -21,13 +21,13 @@
 
 #include <string.h>
 #if defined(STM32F1)
-#	include <libopencm3/stm32/f1/flash.h>
 #	define DFU_IFACE_STRING  "@Internal Flash   /0x08000000/8*001Ka,000*001Kg"
 #   define DFU_IFACE_STRING_OFFSET 38
 #elif defined(STM32F4)
-#	include <libopencm3/stm32/f4/flash.h>
 #	define DFU_IFACE_STRING  "/0x08000000/1*016Ka,3*016Kg,1*064Kg,7*128Kg"
 #endif
+#include <libopencm3/stm32/flash.h>
+
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/usb/dfu.h>
 

--- a/src/platforms/stm32/traceswo.c
+++ b/src/platforms/stm32/traceswo.c
@@ -37,7 +37,7 @@
 
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/timer.h>
-#include <libopencm3/stm32/f1/rcc.h>
+#include <libopencm3/stm32/rcc.h>
 
 void traceswo_init(void)
 {

--- a/src/platforms/stm32/traceswoasync.c
+++ b/src/platforms/stm32/traceswoasync.c
@@ -35,7 +35,7 @@
 #include <libopencmsis/core_cm3.h>
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/timer.h>
-#include <libopencm3/stm32/f1/rcc.h>
+#include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/usart.h>
 #include <libopencm3/stm32/dma.h>
 


### PR DESCRIPTION
The explicit include cause the wrong rcc.h to be included and this gives incoorect values for RCC register access.