### PR TITLE
STM32F1 High density devices DFU support

### DIFF
--- a/src/platforms/stm32/dfucore.c
+++ b/src/platforms/stm32/dfucore.c
@@ -20,9 +20,14 @@
 #include "general.h"
 
 #include <string.h>
-#if defined(STM32F1)
+#if defined(STM32F1HD)
+#	define DFU_IFACE_STRING  "@Internal Flash   /0x08000000/4*002Ka,000*002Kg"
+#   define DFU_IFACE_STRING_OFFSET 38
+#   define DFU_IFACE_PAGESIZE 2
+#elif defined(STM32F1)
 #	define DFU_IFACE_STRING  "@Internal Flash   /0x08000000/8*001Ka,000*001Kg"
 #   define DFU_IFACE_STRING_OFFSET 38
+#   define DFU_IFACE_PAGESIZE 1
 #elif defined(STM32F4)
 #	define DFU_IFACE_STRING  "/0x08000000/1*016Ka,3*016Kg,1*064Kg,7*128Kg"
 #endif
@@ -305,6 +310,7 @@ static void set_dfu_iface_string(uint32_t size)
 {
 	uint32_t res;
 	char *p = if_string + DFU_IFACE_STRING_OFFSET;
+	size /= DFU_IFACE_PAGESIZE;
 	/* We do not want the whole printf library in the bootloader.
 	 * Fill the size digits by hand.
 	 */


### PR DESCRIPTION
Current version of BMP DFU is not working on STM32F103RC chip. The reason is that DFU interface is defined as 8x001Ka + 248x001Kg
In this interface page size is 1K which is correct for medium and low density 103xC devices but high density 103xC devices, such as 103RC have 2K page size. Because of that, dfu-util treats each 2K page as two 1K pages resulting in alternating blank/correct pages

I've replaced interface string with 4x002Ka + 124x002Kg and it works now. Here is small example of possible solution attached - additional define of STM32F1HD is needed in makefile in order to tweak the  interface string