### PR TITLE
fix -Werror,-Wmissing-field-initializers

### DIFF
--- a/src/platforms/pc/cl_utils.c
+++ b/src/platforms/pc/cl_utils.c
@@ -241,7 +241,7 @@ int cl_execute(BMP_CL_OPTIONS_t *opt)
 		DEBUG("Given target nummer %d not available\n", opt->opt_target_dev);
 		return res;
 	}
-	struct target_controller tc = {NULL};
+	struct target_controller tc = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL};
 	target *t = target_attach_n(opt->opt_target_dev, &tc);
 	if (!t) {
 		DEBUG("Can not attach to target %d\n", opt->opt_target_dev);


### PR DESCRIPTION
Building pc-stlinkv2 on MacOS Catalina with clang I got:
```
  CC      platforms/pc/cl_utils.c
platforms/pc/cl_utils.c:244:37: error: missing field 'printf' initializer [-Werror,-Wmissing-field-initializers]
        struct target_controller tc = {NULL};
                                           ^
1 error generated.
```
This pull request explicitly initialises all the fields of the target_controller struct and thus fixes the error.