### PR TITLE
stlink: Do not wait for the reaction on the reset line.

### DIFF
--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -93,12 +93,10 @@ void platform_srst_set_val(bool assert)
 		gpio_set_mode(SRST_PORT, GPIO_MODE_OUTPUT_50_MHZ,
 		              GPIO_CNF_OUTPUT_OPENDRAIN, srst_pin);
 		gpio_clear(SRST_PORT, srst_pin);
-		while (gpio_get(SRST_PORT, srst_pin)) {};
 	} else {
 		gpio_set_mode(SRST_PORT, GPIO_MODE_INPUT,
 			GPIO_CNF_INPUT_PULL_UPDOWN, srst_pin);
 		gpio_set(SRST_PORT, srst_pin);
-		while (!gpio_get(SRST_PORT, srst_pin)) {};
 	}
 }
 


### PR DESCRIPTION
pc-hosted will abort, if the reset line is held externally to some value.
As assert is either driven or driven open drain, we can assume assert
immediate. For deassert, logic levels differences between the debugger and
the debuggee may apply and other ways to check the result are needed, like
CORTEXM_DHCSR_S_RESET_ST.