### PR TITLE
Erase range

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -27,6 +27,7 @@
 #include "command.h"
 #include "gdb_packet.h"
 #include "target.h"
+#include "target/target_internal.h"
 #include "morse.h"
 #include "version.h"
 
@@ -35,13 +36,6 @@
 #endif
 
 typedef bool (*cmd_handler)(target *t, int argc, const char **argv);
-
-struct command_s {
-	const char *cmd;
-	cmd_handler handler;
-
-	const char *help;
-};
 
 static bool cmd_version(target *t, int argc, char **argv);
 static bool cmd_help(target *t, int argc, char **argv);


### PR DESCRIPTION
This is adopted from #458 .Syntax has been changed to "mon erase_range start (len)" and will erase from start to start + len - 1 plus anything that is on the same page before start and anything that is on the same page behind start + len - 1.

Please give feedback if these additional 0x312 bytes in flash are usefull.