### PR TITLE
dfucore: Reject erase outside the allowed range

### DIFF
--- a/src/platforms/stm32/dfucore.c
+++ b/src/platforms/stm32/dfucore.c
@@ -176,9 +176,14 @@ usbdfu_getstatus_complete(usbd_device *dev, struct usb_setup_data *req)
 
 		flash_unlock();
 		if(prog.blocknum == 0) {
-			int32_t addr = get_le32(prog.buf + 1);
+			uint32_t addr = get_le32(prog.buf + 1);
 			switch(prog.buf[0]) {
 			case CMD_ERASE:
+				if ((addr <  app_address) || (addr >= max_address)) {
+					usbdfu_state = 	STATE_DFU_ERROR;
+					flash_lock();
+					return;
+				}
 				dfu_check_and_do_sector_erase(addr);
 			}
 		} else {


### PR DESCRIPTION
An illegal erase request may get emitted as the DFU program may erase
first. Checking range before flashing is too late.