### PR TITLE
BMP/PC: Allow to compile with mingw64.

### DIFF
--- a/src/include/general.h
+++ b/src/include/general.h
@@ -22,7 +22,9 @@
 #define __GENERAL_H
 
 #define _GNU_SOURCE
-#define __USE_MINGW_ANSI_STDIO 1
+#if !defined(__USE_MINGW_ANSI_STDIO)
+# define __USE_MINGW_ANSI_STDIO 1
+#endif
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/src/platforms/pc/cl_utils.c
+++ b/src/platforms/pc/cl_utils.c
@@ -22,13 +22,13 @@
  * binary file from the command line.
  */
 
+#include "general.h"
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 
-#include "general.h"
 #include "target.h"
 #include "target_internal.h"
 

--- a/src/platforms/pc/gdb_if.c
+++ b/src/platforms/pc/gdb_if.c
@@ -24,6 +24,7 @@
  */
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+#   define __USE_MINGW_ANSI_STDIO 1
 #   include <winsock2.h>
 #   include <windows.h>
 #   include <ws2tcpip.h>

--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -31,9 +31,9 @@
  * particularly Sections 12. DSU and 25. NVMCTRL
  */
 
+#include "general.h"
 #include <ctype.h>
 
-#include "general.h"
 #include "target.h"
 #include "target_internal.h"
 #include "cortexm.h"


### PR DESCRIPTION
__USE_MINGW_ANSI_STDIO 1 must be set befor any windows specific included.