### PR TITLE
pc-stlinkv2: Make stlink_usb_get_rw_status static and allow to suppre…

### DIFF
--- a/src/platforms/pc-stlinkv2/stlinkv2.h
+++ b/src/platforms/pc-stlinkv2/stlinkv2.h
@@ -43,7 +43,6 @@ uint32_t stlink_dp_error(ADIv5_DP_t *dp);
 void stlink_dp_abort(ADIv5_DP_t *dp, uint32_t abort);
 int stlink_open_ap(uint8_t ap);
 void stlink_close_ap(uint8_t ap);
-int stlink_usb_get_rw_status(void);
 void stlink_regs_read(ADIv5_AP_t *ap, void *data);
 uint32_t stlink_reg_read(ADIv5_AP_t *ap, int idx);
 void stlink_reg_write(ADIv5_AP_t *ap, int num, uint32_t val);


### PR DESCRIPTION
…ss errors

This helps to not overflow the console.