### PR TITLE
pc/serial_unix: bump device path buffer size to 4096 bytes

### DIFF
--- a/src/platforms/pc/serial_unix.c
+++ b/src/platforms/pc/serial_unix.c
@@ -71,7 +71,7 @@ static int set_interface_attribs(void)
 #define DEVICE_BY_ID "/dev/serial/by-id/"
 int serial_open(BMP_CL_OPTIONS_t *opt)
 {
-	char name[256];
+	char name[4096];
 	if (!opt->opt_device) {
 		/* Try to find some BMP if0*/
 		struct dirent *dp;
@@ -212,4 +212,3 @@ int platform_buffer_read(uint8_t *data, int maxsize)
 	exit(-3);
 	return 0;
 }
-


### PR DESCRIPTION
Since dp->d_name can be up to 255 bytes long and the 'name' buffer variable is is a superset of it, bump the size of the latter to 4096 bytes (correspoding to PATH_MAX on Linux systems).

Without this fix, build fails on Linux system with GCC 9.2.1:

```
  CC      platforms/pc/serial_unix.c
platforms/pc/serial_unix.c: In function ‘serial_open’:
platforms/pc/serial_unix.c:94:5: error: ‘strncat’ output may be truncated copying between 0 and 255 bytes from a string of length 255 [-Werror=stringop-truncation]
   94 |     strncat(name, dp->d_name, sizeof(name) - strlen(name) - 1);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:88: serial_unix.o] Error 1
make: *** [Makefile:30: all] Error 2
```