### PR TITLE
20200405 compilation fixes

### DIFF
--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -419,9 +419,9 @@ static void dfu_detach_complete(usbd_device *dev, struct usb_setup_data *req)
 	scb_reset_core();
 }
 
-static enum usbd_request_return_codes  cdcacm_control_request(usbd_device *dev,
+static int cdcacm_control_request(usbd_device *dev,
 		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-		void (**complete)(usbd_device *dev, struct usb_setup_data *req))
+		usbd_control_complete_callback *complete)
 {
 	(void)dev;
 	(void)complete;

--- a/src/platforms/stm32/blackmagic.ld
+++ b/src/platforms/stm32/blackmagic.ld
@@ -25,5 +25,5 @@ MEMORY
 }
 
 /* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+INCLUDE libopencm3_stm32f1.ld
 

--- a/src/platforms/stm32/dfucore.c
+++ b/src/platforms/stm32/dfucore.c
@@ -208,7 +208,7 @@ usbdfu_getstatus_complete(usbd_device *dev, struct usb_setup_data *req)
 	}
 }
 
-static enum usbd_request_return_codes usbdfu_control_request(usbd_device *dev,
+static int usbdfu_control_request(usbd_device *dev,
 		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
 		void (**complete)(usbd_device *dev, struct usb_setup_data *req))
 {

--- a/src/platforms/stm32/f4discovery.ld
+++ b/src/platforms/stm32/f4discovery.ld
@@ -25,5 +25,5 @@ MEMORY
 }
 
 /* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+INCLUDE libopencm3_stm32f1.ld
 

--- a/src/platforms/stm32/stlink.ld
+++ b/src/platforms/stm32/stlink.ld
@@ -25,4 +25,4 @@ MEMORY
 }
 
 /* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+INCLUDE libopencm3_stm32f1.ld

--- a/src/platforms/stm32/stm32_can.ld
+++ b/src/platforms/stm32/stm32_can.ld
@@ -25,4 +25,4 @@ MEMORY
 }
 
 /* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+INCLUDE libopencm3_stm32f1.ld

--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -219,7 +219,7 @@ void USBUSART_ISR(void)
 #if !defined(USART_SR_NE) && defined(USART_ISR_NF)
 # define USART_SR_NE USART_ISR_NF
 #endif
-	if (err & (USART_FLAG_ORE | USART_FLAG_FE | USART_SR_NE))
+	if (err & (USART_SR_ORE | USART_SR_FE | USART_SR_NE))
 		return;
 
 	/* Turn on LED */


### PR DESCRIPTION
After applying the 'fixes' in this branch I was able to compile and flash a Baite V2 probe with the resulting `blackmagic.bin` and was able to use the probe to upload and debug code to an STM32H750VBT6 target device.

I was greeted with several compilation failures when I tried building using this command:

`make PROBE_HOST=stlink`

my `HEAD` was `846dadcc39df5783988c7f030f722ab55568e6e5`
and `libopencm3` was `383fafc862c0d47f30965f00409d03a328049278`

I used this gcc:

```
arm-none-eabi-gcc.exe (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
```

I don't have a lot of time to contribute to this project due to my workload, but sharing these changes in the hopes that this will be useful to others.
