### PR TITLE
Fixed overrun, when dumping data in swolisten.

### DIFF
--- a/scripts/swolisten.c
+++ b/scripts/swolisten.c
@@ -442,7 +442,10 @@ int usbFeeder(void)
 	{
 	  unsigned char *c=cbw;
           if (options.dump)
-              printf(cbw);
+          {
+              cbw[size] = 0;
+              printf("%s", (char*)cbw);
+          }
           else
               while (size--)
                   _protocolPump(c++);


### PR DESCRIPTION
The swolisten program failed to print the cbw buffer correctly while
in dump mode. As printf() is used to print the dump, it is expected
that the cbw buffer is zero-terminated, which would only be the case,
if the cbw buffer is initialized with zeros, before filling it with
new data. One could set the entire cbw buffer to zero, but it will be
more efficient to only set the size-th byte to zero.

This patch fixes the above problem, by using the size variable to set
the sixe-th byte of the cbw buffer to zero, before passing it to
printf().