### PR TITLE
Special case value-line F750 flash mapping

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -331,29 +331,14 @@ static bool stm32f4_attach(target *t)
 	else
 		banksize = flashsize << 10;
 	if (large_sectors) {
-		// The F750 has the same id code as a F74x, but has a significantly
-		// different memory capacity. If we treat it the same, we will underflow the
-		// size of the final memory region, and generate a close to 4GiB mapping.
-		// To avoid this, match on it's flash size (64KiB)
-		const bool is_stm32f750 = flashsize == 0x40;
-		if (is_stm32f750) {
-			// On STM32F750xx devices, a main memory block divided into 2 sectors of
-			// 32 Kbyte
-			stm32f4_add_flash(t, ITCM_BASE, 0x10000, 0x8000, 0, split);
-			stm32f4_add_flash(t, AXIM_BASE, 0x10000, 0x8000, 0, split);
-		} else {
-			// On STM32F756xx and STM32F74xx devices, a main memory block divided into
-			// 4 sectors of 32 Kbytes, 1 sector of 128 Kbytes and 3 sectors of 256
-			// Kbytes
-			/* 256 k in small sectors.*/
-			uint32_t remains = banksize - 0x40000;
-			stm32f4_add_flash(t, ITCM_BASE, 0x20000, 0x8000, 0, split);
-			stm32f4_add_flash(t, 0x0220000, 0x20000, 0x20000, 4, split);
-			stm32f4_add_flash(t, 0x0240000, remains, 0x40000, 5, split);
-			stm32f4_add_flash(t, AXIM_BASE, 0x20000, 0x8000, 0, split);
-			stm32f4_add_flash(t, 0x8020000, 0x20000, 0x20000, 4, split);
-			stm32f4_add_flash(t, 0x8040000, remains, 0x40000, 5, split);
-		}
+		uint32_t remains = banksize >= 0x40000 ? banksize - 0x40000 : 0;
+		/* 256 k in small sectors.*/
+		stm32f4_add_flash(t, ITCM_BASE, 0x20000,  0x8000, 0, split);
+		stm32f4_add_flash(t, 0x0220000, 0x20000, 0x20000, 4, split);
+		stm32f4_add_flash(t, 0x0240000, remains, 0x40000, 5, split);
+		stm32f4_add_flash(t, AXIM_BASE, 0x20000,  0x8000, 0, split);
+		stm32f4_add_flash(t, 0x8020000, 0x20000, 0x20000, 4, split);
+		stm32f4_add_flash(t, 0x8040000, remains, 0x40000, 5, split);
 	} else {
 		uint32_t remains = 0;
 		if (banksize > 0x20000)

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -331,14 +331,29 @@ static bool stm32f4_attach(target *t)
 	else
 		banksize = flashsize << 10;
 	if (large_sectors) {
-		uint32_t remains = banksize - 0x40000;
-		/* 256 k in small sectors.*/
-		stm32f4_add_flash(t, ITCM_BASE, 0x20000,  0x8000, 0, split);
-		stm32f4_add_flash(t, 0x0220000, 0x20000, 0x20000, 4, split);
-		stm32f4_add_flash(t, 0x0240000, remains, 0x40000, 5, split);
-		stm32f4_add_flash(t, AXIM_BASE, 0x20000,  0x8000, 0, split);
-		stm32f4_add_flash(t, 0x8020000, 0x20000, 0x20000, 4, split);
-		stm32f4_add_flash(t, 0x8040000, remains, 0x40000, 5, split);
+		// The F750 has the same id code as a F74x, but has a significantly
+		// different memory capacity. If we treat it the same, we will underflow the
+		// size of the final memory region, and generate a close to 4GiB mapping.
+		// To avoid this, match on it's flash size (64KiB)
+		const bool is_stm32f750 = flashsize == 0x40;
+		if (is_stm32f750) {
+			// On STM32F750xx devices, a main memory block divided into 2 sectors of
+			// 32 Kbyte
+			stm32f4_add_flash(t, ITCM_BASE, 0x10000, 0x8000, 0, split);
+			stm32f4_add_flash(t, AXIM_BASE, 0x10000, 0x8000, 0, split);
+		} else {
+			// On STM32F756xx and STM32F74xx devices, a main memory block divided into
+			// 4 sectors of 32 Kbytes, 1 sector of 128 Kbytes and 3 sectors of 256
+			// Kbytes
+			/* 256 k in small sectors.*/
+			uint32_t remains = banksize - 0x40000;
+			stm32f4_add_flash(t, ITCM_BASE, 0x20000, 0x8000, 0, split);
+			stm32f4_add_flash(t, 0x0220000, 0x20000, 0x20000, 4, split);
+			stm32f4_add_flash(t, 0x0240000, remains, 0x40000, 5, split);
+			stm32f4_add_flash(t, AXIM_BASE, 0x20000, 0x8000, 0, split);
+			stm32f4_add_flash(t, 0x8020000, 0x20000, 0x20000, 4, split);
+			stm32f4_add_flash(t, 0x8040000, remains, 0x40000, 5, split);
+		}
 	} else {
 		uint32_t remains = 0;
 		if (banksize > 0x20000)


### PR DESCRIPTION
The value-line F750 part has the same idcode as a F745, but only has 64KiB of
flash. If we use the same flash mapping calculation for both, the
`remains` value will **underflow**, resulting in a flash size of
`0xfffd'0000` for the region starting at `0x8040'0000`. This causes GDB
to warn

    Overlapping regions in memory map: ignoring

and causes programming of the F750 part to fail.

This patch adds a check on the flash size of the device, and in the case
of the F750 adds the two smaller sectors.
Memory difference information can be seen on page 77 of ST manual RM0385
(Rev 8).

This patch has been verified to work on an F750 part (STM32F750V8T6), and a true F745 part (STM32F745VET6).