### PR TITLE
stm32f4/7: Always use largest flashsize for device family (#633, #635…

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -213,14 +213,8 @@ static bool stm32h7_attach(target *t)
 	target_add_ram(t, 0x38000000, 0x01000); /* AHB SRAM4,  32 k */
 
 	/* Add the flash to memory map. */
-	uint32_t flashsize = target_mem_read32(t,  FLASH_SIZE_REG);
-	flashsize &= 0xffff;
-	if (flashsize == 128) { /* H750 has only 128 kByte!*/
-		stm32h7_add_flash(t, 0x8000000, FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
-	} else {
-		stm32h7_add_flash(t, 0x8000000, 0x100000, FLASH_SECTOR_SIZE);
-		stm32h7_add_flash(t, 0x8100000, 0x100000, FLASH_SECTOR_SIZE);
-	}
+	stm32h7_add_flash(t, 0x8000000, 0x100000, FLASH_SECTOR_SIZE);
+	stm32h7_add_flash(t, 0x8100000, 0x100000, FLASH_SECTOR_SIZE);
 	return true;
 }
 


### PR DESCRIPTION
…, #644)

Do not care for the FLASHSIZE register. Leave it up to the user to abuse
flash area the ST did not announce.