### PR TITLE
cdcacm: Fix UART interface OUT endpoint MPS in descriptor.

### DIFF
--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -188,7 +188,7 @@ static const struct usb_endpoint_descriptor uart_data_endp[] = {{
 	.bDescriptorType = USB_DT_ENDPOINT,
 	.bEndpointAddress = 0x03,
 	.bmAttributes = USB_ENDPOINT_ATTR_BULK,
-	.wMaxPacketSize = CDCACM_PACKET_SIZE,
+	.wMaxPacketSize = CDCACM_PACKET_SIZE / 2,
 	.bInterval = 1,
 }, {
 	.bLength = USB_DT_ENDPOINT_SIZE,


### PR DESCRIPTION
3e3e450 reduced the buffer size for the UART interface OUT endpoint to
32B, but left wMaxPacketSize at 64B. This effectively configures the
hardware to receive packets up to 32B in size while telling the host it
can send larger packets. On reception of a larger packet, the usb core
treats it as an error, drops the packet and replies with a STALL
handshake.

This commit fixes the issue by updating the descriptor to match the
buffer configuration.

Fixes #538