### PR TITLE
Rename variant_string in efm32 samd samx5x

### DIFF
--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -584,7 +584,7 @@ static efm32_device_t const * efm32_get_device(size_t index)
 /**
  * Probe
  */
-char efm32_variant_string[60];
+static char efm32_variant_string[60];
 bool efm32_probe(target *t)
 {
 	uint8_t di_version = 1;

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -584,7 +584,7 @@ static efm32_device_t const * efm32_get_device(size_t index)
 /**
  * Probe
  */
-char variant_string[60];
+char efm32_variant_string[60];
 bool efm32_probe(target *t)
 {
 	uint8_t di_version = 1;
@@ -636,13 +636,13 @@ bool efm32_probe(target *t)
 	uint32_t ram_size   = ram_kib   * 0x400;
 	uint32_t flash_page_size = device->flash_page_size;
 
-	snprintf(variant_string, sizeof(variant_string), "%c\b%c\b%s %d F%d %s",
+	snprintf(efm32_variant_string, sizeof(efm32_variant_string), "%c\b%c\b%s %d F%d %s",
 			di_version + 48, (uint8_t)device_index + 32,
 			device->name, part_number, flash_kib, device->description);
 
 	/* Setup Target */
 	t->target_options |= CORTEXM_TOPT_INHIBIT_SRST;
-	t->driver = variant_string;
+	t->driver = efm32_variant_string;
 	tc_printf(t, "flash size %d page size %d\n", flash_size, flash_page_size);
 	target_add_ram (t, SRAM_BASE, ram_size);
 	efm32_add_flash(t, 0x00000000, flash_size, flash_page_size);

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -441,7 +441,7 @@ static void samd_add_flash(target *t, uint32_t addr, size_t length)
 	target_add_flash(t, f);
 }
 
-char samd_variant_string[60];
+static char samd_variant_string[60];
 bool samd_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -380,6 +380,7 @@ struct samd_descr samd_parse_device_id(uint32_t did)
 			}
 			break;
 		case 3: samd.series = 11; break;
+		default: samd.series = 0; break;
 	}
 	/* Revision */
 	samd.revision = 'A' + revision;
@@ -440,7 +441,7 @@ static void samd_add_flash(target *t, uint32_t addr, size_t length)
 	target_add_flash(t, f);
 }
 
-char variant_string[60];
+char samd_variant_string[60];
 bool samd_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
@@ -467,14 +468,14 @@ bool samd_probe(target *t)
 
 	/* Part String */
 	if (protected) {
-		sprintf(variant_string,
+		sprintf(samd_variant_string,
 		        "Atmel SAM%c%d%c%d%c%s (rev %c) (PROT=1)",
 		        samd.family,
 		        samd.series, samd.pin, samd.mem,
 		        samd.variant,
 		        samd.package, samd.revision);
 	} else {
-		sprintf(variant_string,
+		sprintf(samd_variant_string,
 		        "Atmel SAM%c%d%c%d%c%s (rev %c)",
 		        samd.family,
 		        samd.series, samd.pin, samd.mem,
@@ -483,7 +484,7 @@ bool samd_probe(target *t)
 	}
 
 	/* Setup Target */
-	t->driver = variant_string;
+	t->driver = samd_variant_string;
 	t->reset = samd_reset;
 
 	if (samd.series == 20 && samd.revision == 'B') {

--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -344,7 +344,7 @@ static void samx5x_add_flash(target *t, uint32_t addr, size_t length,
 	target_add_flash(t, f);
 }
 
-char samx5x_variant_string[60];
+static char samx5x_variant_string[60];
 bool samx5x_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);

--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -344,7 +344,7 @@ static void samx5x_add_flash(target *t, uint32_t addr, size_t length,
 	target_add_flash(t, f);
 }
 
-char variant_string[60];
+char samx5x_variant_string[60];
 bool samx5x_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
@@ -371,19 +371,19 @@ bool samx5x_probe(target *t)
 
 	/* Part String */
 	if (protected) {
-		snprintf(variant_string, sizeof(variant_string),
+		snprintf(samx5x_variant_string, sizeof(samx5x_variant_string),
 			 "Microchip SAM%c%d%c%dA (rev %c) (PROT=1)",
 			 samx5x.series_letter, samx5x.series_number,
 			 samx5x.pin, samx5x.mem, samx5x.revision);
 	} else {
-		snprintf(variant_string, sizeof(variant_string),
+		snprintf(samx5x_variant_string, sizeof(samx5x_variant_string),
 			 "Microchip SAM%c%d%c%dA (rev %c)",
 			 samx5x.series_letter, samx5x.series_number,
 			 samx5x.pin, samx5x.mem, samx5x.revision);
 	}
 
 	/* Setup Target */
-	t->driver = variant_string;
+	t->driver = samx5x_variant_string;
 	t->reset = samx5x_reset;
 
 	if (protected) {


### PR DESCRIPTION
Files efm32 samd samx5x uses same function name that collides during
linking (checked with gcc10)

Signed-off-by: Alexey 'Alexxy' Shvetsov <alexxyum@gmail.com>