### PR TITLE
set semihosting sys_clock time origin

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -71,6 +71,10 @@ static target_addr cortexm_check_watch(target *t);
 
 static int cortexm_hostio_request(target *t);
 
+#if !defined(PC_HOSTED)
+static uint32_t time0_sec = UINT32_MAX; /* sys_clock time origin */
+#endif
+
 struct cortexm_priv {
 	ADIv5_AP_t *ap;
 	bool stepping;
@@ -1206,6 +1210,8 @@ static int cortexm_hostio_request(target *t)
 		if (syscall == SYS_TIME) { /* SYS_TIME: time in seconds */
 			ret = sec;
 		} else { /* SYS_CLOCK: time in hundredths of seconds */
+			if (time0_sec > sec) time0_sec = sec; /* set sys_clock time origin */
+			sec -= time0_sec;
 			uint64_t csec64 = (sec * 1000000ull + usec)/10000ull;
 			uint32_t csec = csec64 & 0x7fffffff;
 			ret = csec;


### PR DESCRIPTION
The semihosting sys_clock is a 32-bit timer that counts in 1/100 second. This patch sets the time origin of sys_clock to the second of first use. This way the counter wraps around after 16 months of uptime; sufficient.