### PR TITLE
traceswo decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ JTAG or Serial Wire Debugging (SWD) port and on-chip debug logic provided
 by the microprocessor. The probe connects to a host computer using a
 standard USB interface. The user is able to control exactly what happens
 using the GNU source level debugging software, GDB.
+Serial Wire Output (SWO) allows the target to write tracing and logging to the host
+without using usb or serial port. Decoding SWO in the probe itself
+makes [SWO viewing as simple as connecting to a serial port](https://github.com/blacksphere/blackmagic/wiki/Serial-Wire-Output).
 
 See online documentation at https://github.com/blacksphere/blackmagic/wiki
 

--- a/src/platforms/common/traceswo.h
+++ b/src/platforms/common/traceswo.h
@@ -23,11 +23,20 @@
 #include <libopencm3/usb/usbd.h>
 
 #if defined TRACESWO_PROTOCOL && TRACESWO_PROTOCOL == 2
-void traceswo_init(uint32_t baudrate);
+/* Default line rate, used as default for a request without baudrate */
+#define SWO_DEFAULT_BAUD (2250000)
+void traceswo_init(uint32_t baudrate, uint32_t swo_chan_bitmask);
 #else
-void traceswo_init(void);
+void traceswo_init(uint32_t swo_chan_bitmask);
 #endif
 
 void trace_buf_drain(usbd_device *dev, uint8_t ep);
+
+/* set bitmask of swo channels to be decoded */
+void traceswo_setmask(uint32_t mask);
+
+/* print decoded swo packet on usb serial */
+uint16_t traceswo_decode(usbd_device *usbd_dev, uint8_t addr,
+				const void *buf, uint16_t len);
 
 #endif

--- a/src/platforms/f4discovery/Makefile.inc
+++ b/src/platforms/f4discovery/Makefile.inc
@@ -16,6 +16,7 @@ LDFLAGS = -lopencm3_stm32f4 \
 VPATH += platforms/stm32
 
 SRC += 	cdcacm.c	\
+	traceswodecode.c	\
 	traceswo.c	\
 	usbuart.c	\
 	serialno.c	\

--- a/src/platforms/hydrabus/Makefile.inc
+++ b/src/platforms/hydrabus/Makefile.inc
@@ -16,6 +16,7 @@ LDFLAGS = -lopencm3_stm32f4 \
 VPATH += platforms/stm32
 
 SRC += 	cdcacm.c	\
+	traceswodecode.c	\
 	traceswo.c	\
 	usbuart.c	\
 	serialno.c	\

--- a/src/platforms/native/Makefile.inc
+++ b/src/platforms/native/Makefile.inc
@@ -21,6 +21,7 @@ endif
 VPATH += platforms/stm32
 
 SRC += 	cdcacm.c	\
+	traceswodecode.c	\
 	traceswo.c	\
 	usbuart.c	\
 	serialno.c	\

--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -32,6 +32,7 @@ SRC += 	cdcacm.c	\
 	serialno.c	\
 	timing.c	\
 	timing_stm32.c	\
+	traceswodecode.c	\
 	traceswoasync.c	\
 	stlink_common.c \
 

--- a/src/platforms/stm32/traceswodecode.c
+++ b/src/platforms/stm32/traceswodecode.c
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Print decoded swo stream on the usb serial */
+
+#include "general.h"
+#include "cdcacm.h"
+#include "traceswo.h"
+
+/* SWO decoding */
+/* data is static in case swo packet is astride two buffers */
+static uint8_t swo_buf[CDCACM_PACKET_SIZE];
+static int swo_buf_len = 0;
+static uint32_t swo_decode = 0; /* bitmask of channels to print */
+static int swo_pkt_len = 0; /* decoder state */
+static bool swo_print = false;
+
+/* print decoded swo packet on usb serial */
+uint16_t traceswo_decode(usbd_device *usbd_dev, uint8_t addr,
+				const void *buf, uint16_t len) {
+	if (usbd_dev == NULL) return 0;
+	for (int i = 0; i<len; i++) {
+		uint8_t ch=((uint8_t*)buf)[i];
+		if (swo_pkt_len == 0) { /* header */
+			uint32_t channel = (uint32_t)ch >> 3; /* channel number */
+			uint32_t size = ch & 0x7; /* drop channel number */
+			if (size == 0x01) swo_pkt_len = 1;      /* SWO packet 0x01XX */
+			else if (size == 0x02) swo_pkt_len = 2; /* SWO packet 0x02XXXX */
+			else if (size == 0x03) swo_pkt_len = 4; /* SWO packet 0x03XXXXXXXX */
+			swo_print = (swo_pkt_len != 0) && ((swo_decode & (1UL << channel)) != 0UL);
+		} else if (swo_pkt_len <= 4) { /* data */
+			if (swo_print) {
+				swo_buf[swo_buf_len++]=ch;
+				if (swo_buf_len == sizeof(swo_buf)) {
+					if (cdcacm_get_config() && cdcacm_get_dtr()) /* silently drop if usb not ready */
+						usbd_ep_write_packet(usbd_dev, addr, swo_buf, swo_buf_len);
+					swo_buf_len=0;
+				}
+			}
+			--swo_pkt_len;
+		} else { /* recover */
+			swo_buf_len=0;
+			swo_pkt_len=0;
+		}
+	}
+	return len;
+}
+
+/* set bitmask of swo channels to be decoded */
+void traceswo_setmask(uint32_t mask) {
+	swo_decode = mask;
+}
+
+/* not truncated */

--- a/src/platforms/swlink/Makefile.inc
+++ b/src/platforms/swlink/Makefile.inc
@@ -25,6 +25,7 @@ SRC += 	cdcacm.c	\
 	serialno.c	\
 	timing.c	\
 	timing_stm32.c	\
+	traceswodecode.c	\
 	traceswoasync.c	\
 	platform_common.c \
 


### PR DESCRIPTION
This patch decodes traceswo in the probe itself. The output goes to the usb serial port.
Adds "decode" option to "traceswo" command.
Increases stlink firmware size by 360 bytes, or by 464 bytes if ENABLE_DEBUG=1.
Note: only tested on stm32f103/stlink.