### PR TITLE
When timeout is 0, `timeout_is_expired()` should return immediately.

### DIFF
--- a/src/platforms/common/timing.c
+++ b/src/platforms/common/timing.c
@@ -26,6 +26,5 @@ void platform_timeout_set(platform_timeout *t, uint32_t ms)
 
 bool platform_timeout_is_expired(platform_timeout *t)
 {
-	return platform_time_ms() > t->time;
+	return platform_time_ms() >= t->time;
 }
-


### PR DESCRIPTION
Commit 8b4342394fa125 changed the behavior of timeout, when timeout is set to 0.  Previous behavior was to return immediately.  Present behavior is to wait at least 1 ms to return.

On the STM32 platform, the timer is only updated every 100 ms.  So a timeout of 0 will take (up to) 100 ms to time out.

In `gdb_main.c`, there is a call `gdb_if_getchar_to(0)` inside a loop. This is meant to be a nonblocking call, but the error in 8b4342394fa125 means each iteration through the loop takes a full 100 ms.

I have an application that runs many small stub programs from RAM, and the extra latency is quite noticeable.
