### PR TITLE
Support for LPC8N04 (UM11074)

### DIFF
--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -129,6 +129,12 @@ lpc11xx_probe(target *t)
 		target_add_ram(t, 0x10000000, 0x2000);
 		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x1000);
 		return true;
+	case 0x00008A04:  /* LPC8N04 (see UM11074 Rev.1.3 section 4.5.19) */
+		t->driver = "LPC8N04";
+		target_add_ram(t, 0x10000000, 0x2000);
+		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400);
+		target_add_commands(t, lpc11xx_cmd_list, "LPC8N04");
+		return true;
 	}
 	if (idcode) {
 		DEBUG("LPC11xx: Unknown IDCODE 0x%08" PRIx32 "\n", idcode);


### PR DESCRIPTION
Adds support for the LPC8N04 device documented in UM11074 (rev. 1.3, latest needs an NXP login).

SWD information from debug mode:

```
RESET_SEQ succeeded
AP   0: IDR=04770031 CFG=00000000 BASE=e00ff003 CSW=03000040
ROM: Table BASE=0xe00ff000 SYSMEM=0x1, PIDR 0x04000bb4c0
0 0xe000e000: Generic IP component - Cortex-M0 SCS (System Control Space) (PIDR = 0x04000bb008)-> cortexm_probe
1 0xe0001000: Generic IP component - Cortex-M0 DWT (Data Watchpoint and Trace) (PIDR = 0x04000bb00a)
2 0xe0002000: Generic IP component - Cortex-M0 BPU (Breakpoint Unit) (PIDR = 0x04000bb00b)
ROM: Table END
```

With patch:

```
(gdb) mon s
Target voltage: 3.3V
Available Targets:
No. Att Driver
 1      LPC8N04 M0+
```