### PR TITLE
hydrabus: Disable DFU file generation untit somebody fixes dfu-conver…

### DIFF
--- a/src/platforms/hydrabus/Makefile.inc
+++ b/src/platforms/hydrabus/Makefile.inc
@@ -23,7 +23,7 @@ SRC += 	cdcacm.c	\
 	timing.c	\
 	timing_stm32.c	\
 
-all: blackmagic.bin blackmagic.hex blackmagic.dfu
+all: blackmagic.bin blackmagic.hex
 
 blackmagic.dfu: blackmagic.hex
 	@echo Creating $@


### PR DESCRIPTION
…t.py

This allows "make all_platforms" to succeed on python3 only systems.