### PR TITLE
Remove extra definitions of jtag structures in the STLink hosted setup to support "gcc (GCC) 10.1.0" on Archlinux

### DIFF
--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1027,10 +1027,6 @@ static uint32_t stlink_ap_read(ADIv5_AP_t *ap, uint16_t addr)
 	return ret;
 }
 
-struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS+1];
-int jtag_dev_count;
-jtag_proc_t jtag_proc;
-
 int jtag_scan_stlinkv2(bmp_info_t *info, const uint8_t *irlens)
 {
 	uint32_t idcodes[JTAG_MAX_DEVS+1];


### PR DESCRIPTION
These definitions cause the hosted build to fail, and the STLink build at least _appears_ to be happy without them.