### PR TITLE
Use correct IAP entry address for LPC84x

### DIFF
--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -29,7 +29,8 @@
 #define MIN_RAM_SIZE            1024
 #define RAM_USAGE_FOR_IAP_ROUTINES	32	/* IAP routines use 32 bytes at top of ram */
 
-#define IAP_ENTRYPOINT	0x1fff1ff1
+#define IAP_ENTRY_MOST	0x1fff1ff1	/* all except LPC84x */
+#define IAP_ENTRY_84x	0x0f001ff1
 #define IAP_RAM_BASE	0x10000000
 
 #define LPC11XX_DEVICE_ID  0x400483F4
@@ -55,13 +56,13 @@ const struct command_s lpc11xx_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-void lpc11xx_add_flash(target *t, uint32_t addr, size_t len, size_t erasesize)
+void lpc11xx_add_flash(target *t, uint32_t addr, size_t len, size_t erasesize, uint32_t iap_entry)
 {
 	struct lpc_flash *lf = lpc_add_flash(t, addr, len);
 	lf->f.blocksize = erasesize;
 	lf->f.buf_size = IAP_PGM_CHUNKSIZE;
 	lf->f.write = lpc_flash_write_magic_vect;
-	lf->iap_entry = IAP_ENTRYPOINT;
+	lf->iap_entry = iap_entry;
 	lf->iap_ram = IAP_RAM_BASE;
 	lf->iap_msp = IAP_RAM_BASE + MIN_RAM_SIZE - RAM_USAGE_FOR_IAP_ROUTINES;
 }
@@ -108,7 +109,7 @@ lpc11xx_probe(target *t)
 	case 0x2980002B:	/* lpc11u24x/401 */
 		t->driver = "LPC11xx";
 		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000);
+		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST);
 		target_add_commands(t, lpc11xx_cmd_list, "LPC11xx");
 		return true;
 
@@ -116,23 +117,23 @@ lpc11xx_probe(target *t)
 	case 0x1A24902B:
 		t->driver = "LPC1112";
 		target_add_ram(t, 0x10000000, 0x1000);
-		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x1000);
+		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x1000, IAP_ENTRY_MOST);
 		return true;
     case 0x1000002b: // FX LPC11U6 32 kB SRAM/256 kB flash (max)
 		t->driver = "LPC11U6";
 		target_add_ram(t, 0x10000000, 0x8000);
-		lpc11xx_add_flash(t, 0x00000000, 0x40000, 0x1000);
+		lpc11xx_add_flash(t, 0x00000000, 0x40000, 0x1000, IAP_ENTRY_MOST);
 		return true;
 	case 0x3000002B:
 	case 0x3D00002B:
 		t->driver = "LPC1343";
 		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x1000);
+		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x1000, IAP_ENTRY_MOST);
 		return true;
 	case 0x00008A04:  /* LPC8N04 (see UM11074 Rev.1.3 section 4.5.19) */
 		t->driver = "LPC8N04";
 		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400);
+		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST);
 		target_add_commands(t, lpc11xx_cmd_list, "LPC8N04");
 		return true;
 	}
@@ -148,7 +149,7 @@ lpc11xx_probe(target *t)
 	case 0x00008122:  /* LPC812M101JDH20 / LPC812M101JTB16 */
 		t->driver = "LPC81x";
 		target_add_ram(t, 0x10000000, 0x1000);
-		lpc11xx_add_flash(t, 0x00000000, 0x4000, 0x400);
+		lpc11xx_add_flash(t, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST);
 		target_add_commands(t, lpc11xx_cmd_list, "LPC81x");
 		return true;
 	case 0x00008221:  /* LPC822M101JHI33 */
@@ -157,7 +158,7 @@ lpc11xx_probe(target *t)
 	case 0x00008242:  /* LPC824M201JDH20 */
 		t->driver = "LPC82x";
 		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400);
+		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST);
 		target_add_commands(t, lpc11xx_cmd_list, "LPC82x");
 		return true;
 	case 0x00008441:
@@ -166,7 +167,7 @@ lpc11xx_probe(target *t)
 	case 0x00008444:
 		t->driver = "LPC844";
 		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x400);
+		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x);
 		return true;
 	case 0x00008451:
 	case 0x00008452:
@@ -174,7 +175,7 @@ lpc11xx_probe(target *t)
 	case 0x00008454:
 		t->driver = "LPC845";
 		target_add_ram(t, 0x10000000, 0x4000);
-		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x400);
+		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x);
 		return true;
 	case 0x0003D440:	/* LPC11U34/311  */
 	case 0x0001cc40:	/* LPC11U34/421  */
@@ -186,13 +187,13 @@ lpc11xx_probe(target *t)
 	case 0x00007C40:	/* LPC11U37FBD64/501  */
 		t->driver = "LPC11U3x";
 		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000);
+		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST);
 		return true;
 	case 0x00040070:	/* LPC1114/333 */
 	case 0x00050080:	/* lpc1115XL */
 		t->driver = "LPC1100XL";
 		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000);
+		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST);
 		return true;
 	}
 	if (idcode) {


### PR DESCRIPTION
LPC84x uses a different address for IAP entry function compared to other LPC microcontrollers. Flash operations will not work unless we use the correct IAP entry address.

![2020-08-14-130147_1700x917_scrot](https://user-images.githubusercontent.com/606010/90274313-55595080-de2e-11ea-8d67-3c426d582386.png)
