### PR TITLE
moving the library argument to the end of the command line

### DIFF
--- a/UsingSWO
+++ b/UsingSWO
@@ -111,7 +111,7 @@ information on how to use a dongle.
 
 The command line to build the swolisten tool is;
 
-gcc -I /usr/local/include/libusb-1.0 -L /usr/local/lib  -lusb-1.0 swolisten.c -o swolisten
+gcc -I /usr/local/include/libusb-1.0 -L /usr/local/lib swolisten.c -o swolisten -lusb-1.0
 
 For Opensuse:
 gcc -I /usr/include/libusb-1.0 -lusb-1.0 swolisten.c  swolisten -std=gnu99 -g -Og


### PR DESCRIPTION
I spent a few hours trying to compile swolisten from the UsingSWO documentation and although I had all my library links correct, I still got compilation errors:

```
$ gcc -I ../src/platforms/common/ -I ../libopencm3/include/ -I /usr/include/libusb-1.0 -L /usr/lib/x86_64-linux-gnu/ -lusb-1.0 swolisten.c -o swolisten
/usr/bin/ld: /tmp/ccD4ci7D.o: in function `usbFeeder':
swolisten.c:(.text+0x97f): undefined reference to `libusb_init'
/usr/bin/ld: swolisten.c:(.text+0x9de): undefined reference to `libusb_open_device_with_vid_pid'
/usr/bin/ld: swolisten.c:(.text+0x9f5): undefined reference to `libusb_get_device'
/usr/bin/ld: swolisten.c:(.text+0xa15): undefined reference to `libusb_claim_interface'
/usr/bin/ld: swolisten.c:(.text+0xa9e): undefined reference to `libusb_bulk_transfer'
/usr/bin/ld: swolisten.c:(.text+0xab2): undefined reference to `libusb_close'
collect2: error: ld returned 1 exit status
```

the answer is that the library link has to be at the end of the command
(https://stackoverflow.com/a/2487723/7295116)

by changing this, I get a good compile. Documentation updated to reflect this.