### PR TITLE
Add comments for hardware revision of v2.1

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -43,6 +43,7 @@ static void setup_vbus_irq(void);
  * 000 - Original production build.
  * 001 - Mini production build.
  * 010 - Mini V2.0e and later.
+ * 011 - Mini V2.1e and later.
  */
 int platform_hwversion(void)
 {


### PR DESCRIPTION
Many places are using hardware revision 3 such as https://github.com/blacksphere/blackmagic/blob/46b681e050bbfb27acafab88a3b67bda292825ca/src/platforms/native/platform.c#L201, it will nice to explain that the hardware revision 3 belong to the mini v2.1e and later in the comments.