### PR TITLE
f4discovery: Slow done JTAG pins so avoid ringing.

### DIFF
--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -81,10 +81,13 @@ void platform_init(void)
 			TCK_PIN | TDI_PIN);
 	gpio_mode_setup(JTAG_PORT, GPIO_MODE_INPUT,
 			GPIO_PUPD_NONE, TMS_PIN);
-
+	gpio_set_output_options(JTAG_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ,
+							TCK_PIN | TDI_PIN | TMS_PIN);
 	gpio_mode_setup(TDO_PORT, GPIO_MODE_INPUT,
 			GPIO_PUPD_NONE,
 			TDO_PIN);
+	gpio_set_output_options(TDO_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ,
+							 TDO_PIN| TMS_PIN);
 
 	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT,
 			GPIO_PUPD_NONE,


### PR DESCRIPTION
At GPIO OSPEED 50 MHz, signals showed excessive ringing. Slowing down GPIO OSPEED  to 2 MHz let me scan a Nucleo-H743 only directly connected by SWCLK and SWDIO and ground connected only by the USB cable and a common hub. On the scope edges have sensible risetime, with shortest low and high time around 50 ns.