### PR TITLE
swdptap: Turnaround immediate after a reading with parity.

### DIFF
--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -117,6 +117,8 @@ static bool swdptap_seq_in_parity(uint32_t *ret, int ticks)
 		DEBUG("%d", (res & (1 << i)) ? 1 : 0);
 #endif
 	*ret = res;
+	/* Terminate the read cycle now */
+	swdptap_turnaround(SWDIO_STATUS_DRIVE);
 	return (parity & 1);
 }
 


### PR DESCRIPTION
Thanks to JojoS.
Probably mostly cosmetic, but is keeps the device from driving SWDIO
until the next commands.