### PR TITLE
stm32h7: Don't tc_printf from flash functions

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -252,7 +252,6 @@ static bool stm32h7_flash_unlock(target *t, uint32_t addr)
 	}
 	uint32_t sr = target_mem_read32(t, regbase + FLASH_SR);
 	if (sr & FLASH_SR_ERROR_MASK) {
-		tc_printf(t, "Error 0x%08lx", sr & FLASH_SR_ERROR_MASK);
 		target_mem_write32(t, regbase + FLASH_CCR, sr & FLASH_SR_ERROR_MASK);
 		return false;
 	}

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -250,9 +250,10 @@ static bool stm32h7_flash_unlock(target *t, uint32_t addr)
 		if(target_check_error(t))
 			return false;
 	}
-	uint32_t sr = target_mem_read32(t, regbase + FLASH_SR);
-	if (sr & FLASH_SR_ERROR_MASK) {
-		target_mem_write32(t, regbase + FLASH_CCR, sr & FLASH_SR_ERROR_MASK);
+	uint32_t sr = target_mem_read32(t, regbase + FLASH_SR) & FLASH_SR_ERROR_MASK;
+	if (sr) {
+		DEBUG_WARN("%s error 0x%08" PRIx32, __func__, sr);
+		target_mem_write32(t, regbase + FLASH_CCR, sr);
 		return false;
 	}
 	if (target_mem_read32(t, regbase + FLASH_CR) & FLASH_CR_LOCK) {


### PR DESCRIPTION
Receving an 'O' packet while flashing confuses GDB and then weird stuff happens.