### PR TITLE
Hosted/Firmware: Fix Jtag high level #756

### DIFF
--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -45,6 +45,5 @@ bool platform_srst_get_val(void);
 bool platform_target_get_power(void);
 void platform_target_set_power(bool power);
 void platform_request_boot(void);
-
 #endif
 

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -345,7 +345,7 @@ void remote_adiv5_dp_defaults(ADIv5_DP_t *dp)
 			"Please update BMP firmware for substantial speed increase!\n");
 		return;
 	}
-	if (dp->dev) {
+	if (dp->dp_jd_index < JTAG_MAX_DEVS) {
 		DEBUG_WARN("Falling back to ll as high level JTAG is not yet possible!\n");
 		return;
 	}

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -345,6 +345,10 @@ void remote_adiv5_dp_defaults(ADIv5_DP_t *dp)
 			"Please update BMP firmware for substantial speed increase!\n");
 		return;
 	}
+	if (dp->dev) {
+		DEBUG_WARN("Falling back to ll as high level JTAG is not yet possible!\n");
+		return;
+	}
 	dp->low_access = remote_adiv5_low_access;
 	dp->dp_read    = remote_adiv5_dp_read;
 	dp->ap_write   = remote_adiv5_ap_write;

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -39,5 +39,6 @@ void remote_srst_set_val(bool assert);
 bool remote_srst_get_val(void);
 const char *platform_target_voltage(void);
 void remote_adiv5_dp_defaults(ADIv5_DP_t *dp);
+void remote_add_jtag_dev(int i, const jtag_dev_t *jtag_dev);
 #define __BMP_REMOTE_H_
 #endif

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -339,8 +339,7 @@ uint32_t dap_read_reg(ADIv5_DP_t *dp, uint8_t reg)
 {
 	uint8_t buf[8];
 	uint8_t dap_index = 0;
-	if (dp->dev)
-		dap_index = dp->dev->jd_dev;
+	dap_index = dp->dp_jd_index;
 	buf[0] = ID_DAP_TRANSFER;
 	buf[1] = dap_index;
 	buf[2] = 0x01; // Request size
@@ -358,8 +357,7 @@ void dap_write_reg(ADIv5_DP_t *dp, uint8_t reg, uint32_t data)
 
 	buf[0] = ID_DAP_TRANSFER;
 	uint8_t dap_index = 0;
-	if (dp->dev)
-		dap_index = dp->dev->jd_dev;
+	dap_index = dp->dp_jd_index;
 	buf[1] = dap_index;
 	buf[2] = 0x01; // Request size
 	buf[3] = reg & ~DAP_TRANSFER_RnW;;
@@ -390,8 +388,7 @@ unsigned int dap_read_block(ADIv5_AP_t *ap, void *dest, uint32_t src,
 	uint8_t buf[1024];
 	unsigned int sz = len >> align;
 	uint8_t dap_index = 0;
-	if (ap->dp->dev)
-		dap_index = ap->dp->dev->jd_dev;
+	dap_index = ap->dp->dp_jd_index;
     buf[0] = ID_DAP_TRANSFER_BLOCK;
     buf[1] = dap_index;
     buf[2] =  sz & 0xff;
@@ -426,8 +423,7 @@ unsigned int dap_write_block(ADIv5_AP_t *ap, uint32_t dest, const void *src,
 	uint8_t buf[1024];
 	unsigned int sz = len >> align;
 	uint8_t dap_index = 0;
-	if (ap->dp->dev)
-		dap_index = ap->dp->dev->jd_dev;
+	dap_index = ap->dp->dp_jd_index;
     buf[0] = ID_DAP_TRANSFER_BLOCK;
     buf[1] = dap_index;
     buf[2] =  sz & 0xff;
@@ -527,8 +523,7 @@ static uint8_t *mem_access_setup(ADIv5_AP_t *ap, uint8_t *p,
 		break;
 	}
 	uint8_t dap_index = 0;
-	if (ap->dp->dev)
-		dap_index = ap->dp->dev->jd_dev;
+	dap_index = ap->dp->dp_jd_index;
 	*p++ = ID_DAP_TRANSFER;
 	*p++ = dap_index;
 	*p++ = 3; /* Nr transfers */
@@ -563,8 +558,7 @@ uint32_t dap_ap_read(ADIv5_AP_t *ap, uint16_t addr)
 	uint8_t buf[63], *p = buf;
 	buf[0] = ID_DAP_TRANSFER;
 	uint8_t dap_index = 0;
-	if (ap->dp->dev)
-		dap_index = ap->dp->dev->jd_dev;
+	dap_index = ap->dp->dp_jd_index;
 	*p++ = ID_DAP_TRANSFER;
 	*p++ = dap_index;
 	*p++ = 2; /* Nr transfers */
@@ -584,8 +578,7 @@ void dap_ap_write(ADIv5_AP_t *ap, uint16_t addr, uint32_t value)
 	DEBUG_PROBE("dap_ap_write addr %04x value %08x\n", addr, value);
 	uint8_t buf[63], *p = buf;
 	uint8_t dap_index = 0;
-	if (ap->dp->dev)
-		dap_index = ap->dp->dev->jd_dev;
+	dap_index = ap->dp->dp_jd_index;
 	*p++ = ID_DAP_TRANSFER;
 	*p++ = dap_index;
 	*p++ = 2; /* Nr transfers */

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -340,7 +340,7 @@ uint32_t dap_read_reg(ADIv5_DP_t *dp, uint8_t reg)
 	uint8_t buf[8];
 	uint8_t dap_index = 0;
 	if (dp->dev)
-		dap_index = dp->dev->dev;
+		dap_index = dp->dev->jd_dev;
 	buf[0] = ID_DAP_TRANSFER;
 	buf[1] = dap_index;
 	buf[2] = 0x01; // Request size
@@ -359,7 +359,7 @@ void dap_write_reg(ADIv5_DP_t *dp, uint8_t reg, uint32_t data)
 	buf[0] = ID_DAP_TRANSFER;
 	uint8_t dap_index = 0;
 	if (dp->dev)
-		dap_index = dp->dev->dev;
+		dap_index = dp->dev->jd_dev;
 	buf[1] = dap_index;
 	buf[2] = 0x01; // Request size
 	buf[3] = reg & ~DAP_TRANSFER_RnW;;
@@ -391,7 +391,7 @@ unsigned int dap_read_block(ADIv5_AP_t *ap, void *dest, uint32_t src,
 	unsigned int sz = len >> align;
 	uint8_t dap_index = 0;
 	if (ap->dp->dev)
-		dap_index = ap->dp->dev->dev;
+		dap_index = ap->dp->dev->jd_dev;
     buf[0] = ID_DAP_TRANSFER_BLOCK;
     buf[1] = dap_index;
     buf[2] =  sz & 0xff;
@@ -427,7 +427,7 @@ unsigned int dap_write_block(ADIv5_AP_t *ap, uint32_t dest, const void *src,
 	unsigned int sz = len >> align;
 	uint8_t dap_index = 0;
 	if (ap->dp->dev)
-		dap_index = ap->dp->dev->dev;
+		dap_index = ap->dp->dev->jd_dev;
     buf[0] = ID_DAP_TRANSFER_BLOCK;
     buf[1] = dap_index;
     buf[2] =  sz & 0xff;
@@ -528,7 +528,7 @@ static uint8_t *mem_access_setup(ADIv5_AP_t *ap, uint8_t *p,
 	}
 	uint8_t dap_index = 0;
 	if (ap->dp->dev)
-		dap_index = ap->dp->dev->dev;
+		dap_index = ap->dp->dev->jd_dev;
 	*p++ = ID_DAP_TRANSFER;
 	*p++ = dap_index;
 	*p++ = 3; /* Nr transfers */
@@ -564,7 +564,7 @@ uint32_t dap_ap_read(ADIv5_AP_t *ap, uint16_t addr)
 	buf[0] = ID_DAP_TRANSFER;
 	uint8_t dap_index = 0;
 	if (ap->dp->dev)
-		dap_index = ap->dp->dev->dev;
+		dap_index = ap->dp->dev->jd_dev;
 	*p++ = ID_DAP_TRANSFER;
 	*p++ = dap_index;
 	*p++ = 2; /* Nr transfers */
@@ -585,7 +585,7 @@ void dap_ap_write(ADIv5_AP_t *ap, uint16_t addr, uint32_t value)
 	uint8_t buf[63], *p = buf;
 	uint8_t dap_index = 0;
 	if (ap->dp->dev)
-		dap_index = ap->dp->dev->dev;
+		dap_index = ap->dp->dev->jd_dev;
 	*p++ = ID_DAP_TRANSFER;
 	*p++ = dap_index;
 	*p++ = 2; /* Nr transfers */

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -392,6 +392,12 @@ int platform_swdptap_init(void)
 	return -1;
 }
 
+void platform_add_jtag_dev(int i, const jtag_dev_t *jtag_dev)
+{
+	if (info.bmp_type == BMP_TYPE_BMP)
+		remote_add_jtag_dev(i, jtag_dev);
+}
+
 int platform_jtag_scan(const uint8_t *lrlens)
 {
 	switch (info.bmp_type) {

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1041,10 +1041,10 @@ int jtag_scan_stlinkv2(bmp_info_t *info, const uint8_t *irlens)
 	jtag_dev_count = stlink_read_idcodes(info, idcodes);
 	/* Check for known devices and handle accordingly */
 	for(int i = 0; i < jtag_dev_count; i++)
-		jtag_devs[i].idcode = idcodes[i];
+		jtag_devs[i].jd_idcode = idcodes[i];
 	for(int i = 0; i < jtag_dev_count; i++)
 		for(int j = 0; dev_descr[j].idcode; j++)
-			if((jtag_devs[i].idcode & dev_descr[j].idmask) ==
+			if((jtag_devs[i].jd_idcode & dev_descr[j].idmask) ==
 			   dev_descr[j].idcode) {
 				if(dev_descr[j].handler)
 					dev_descr[j].handler(&jtag_devs[i]);

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1047,7 +1047,7 @@ int jtag_scan_stlinkv2(bmp_info_t *info, const uint8_t *irlens)
 			if((jtag_devs[i].jd_idcode & dev_descr[j].idmask) ==
 			   dev_descr[j].idcode) {
 				if(dev_descr[j].handler)
-					dev_descr[j].handler(&jtag_devs[i]);
+					dev_descr[j].handler(i, dev_descr[j].idcode);
 				break;
 			}
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -126,12 +126,10 @@ static void _respondS(char respCode, const char *s)
 }
 
 static ADIv5_DP_t remote_dp = {
-	.dp_read = firmware_swdp_read,
 	.ap_read = firmware_ap_read,
 	.ap_write = firmware_ap_write,
 	.mem_read = firmware_mem_read,
 	.mem_write_sized = firmware_mem_write_sized,
-	.low_access = firmware_swdp_low_access,
 };
 
 
@@ -144,6 +142,8 @@ void remotePacketProcessSWD(uint8_t i, char *packet)
 	switch (packet[1]) {
     case REMOTE_INIT: /* SS = initialise =============================== */
 		if (i==2) {
+			remote_dp.dp_read = firmware_swdp_read;
+			remote_dp.low_access = firmware_swdp_low_access;
 			swdptap_init();
 			_respond(REMOTE_RESP_OK, 0);
 		} else {
@@ -192,9 +192,9 @@ void remotePacketProcessJTAG(uint8_t i, char *packet)
 
 	switch (packet[1]) {
     case REMOTE_INIT: /* JS = initialise ============================= */
-		jtagtap_init();
 		remote_dp.dp_read = fw_adiv5_jtagdp_read;
 		remote_dp.low_access = fw_adiv5_jtagdp_low_access;
+		jtagtap_init();
 		_respond(REMOTE_RESP_OK, 0);
 		break;
 

--- a/src/remote.h
+++ b/src/remote.h
@@ -147,7 +147,7 @@
 #define REMOTE_MEM_READ_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_MEM_READ, \
 			HEX_U32(address), HEX_U32(count), REMOTE_EOM, 0 }
 #define REMOTE_DP_READ_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_DP_READ, \
-			'f', 'f','%', '0', '4', 'x', REMOTE_EOM, 0 }
+			'%', '0', '4', 'x', REMOTE_EOM, 0 }
 #define REMOTE_LOW_ACCESS_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_LOW_ACCESS, \
 			'%','0', '2', 'x', '%', '0', '4', 'x', HEX_U32(csw), REMOTE_EOM, 0 }
 #define REMOTE_AP_READ_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_READ, \

--- a/src/remote.h
+++ b/src/remote.h
@@ -76,6 +76,7 @@
 #define REMOTE_VOLTAGE      'V'
 #define REMOTE_SRST_SET     'Z'
 #define REMOTE_SRST_GET     'z'
+#define REMOTE_ADD_JTAG_DEV 'J'
 
 /* Protocol response options */
 #define REMOTE_RESP_OK     'K'
@@ -85,6 +86,7 @@
 
 /* High level protocol elements */
 #define REMOTE_HL_CHECK     'C'
+#define REMOTE_HL_JTAG_DEV  'J'
 #define REMOTE_HL_PACKET 'H'
 #define REMOTE_DP_READ      'd'
 #define REMOTE_LOW_ACCESS   'L'
@@ -137,13 +139,25 @@
 
 #define REMOTE_JTAG_NEXT (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_NEXT, \
                                        '%','c','%','c',REMOTE_EOM, 0 }
-
 /* HL protocol elements */
 #define HEX '%', '0', '2', 'x'
 #define HEX_U32(x) '%', '0', '8', 'x'
 #define CHR(x) '%', 'c'
 
+#define REMOTE_JTAG_ADD_DEV_STR (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET,\
+			REMOTE_ADD_JTAG_DEV,											\
+			'%','0','2','x', /* index */								\
+			'%','0','2','x', /* dr_prescan */							\
+			'%','0','2','x', /*	dr_postscan	*/							\
+			'%','0','2','x', /* ir_len */								\
+			'%','0','2','x', /* ir_prescan */							\
+			'%','0','2','x', /* ir_postscan */							\
+			HEX_U32(current_ir), /* current_ir */						\
+			REMOTE_EOM, 0}
+
 #define REMOTE_HL_CHECK_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_HL_CHECK, REMOTE_EOM, 0 }
+#define REMOTE_HL_JTAG_DEV_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, \
+			REMOTE_HL_JTAG_DEV, '%', '0', '2', 'x', REMOTE_EOM, 0 }
 #define REMOTE_MEM_READ_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_MEM_READ, \
 			HEX_U32(address), HEX_U32(count), REMOTE_EOM, 0 }
 #define REMOTE_DP_READ_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_DP_READ, \

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -260,8 +260,10 @@ void adiv5_dp_write(ADIv5_DP_t *dp, uint16_t addr, uint32_t value);
 void adiv5_dp_init(ADIv5_DP_t *dp);
 void platform_adiv5_dp_defaults(ADIv5_DP_t *dp);
 ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel);
+void remote_jtag_dev(const jtag_dev_t *jtag_dev);
 void adiv5_ap_ref(ADIv5_AP_t *ap);
 void adiv5_ap_unref(ADIv5_AP_t *ap);
+void platform_add_jtag_dev(const int dev_index, const jtag_dev_t *jtag_dev);
 
 void adiv5_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode);
 int platform_jtag_dp_init(ADIv5_DP_t *dp);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -174,15 +174,8 @@ typedef struct ADIv5_DP_s {
 	void (*mem_read)(ADIv5_AP_t *ap, void *dest, uint32_t src, size_t len);
 	void (*mem_write_sized)(ADIv5_AP_t *ap, uint32_t dest, const void *src,
 							size_t len, enum align align);
-#if PC_HOSTED == 1
-	jtag_dev_t *dev;
+	uint8_t dp_jd_index;
 	uint8_t fault;
-#else
-	union {
-		jtag_dev_t *dev;
-		uint8_t fault;
-	};
-#endif
 } ADIv5_DP_t;
 
 struct ADIv5_AP_s {
@@ -270,7 +263,7 @@ ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel);
 void adiv5_ap_ref(ADIv5_AP_t *ap);
 void adiv5_ap_unref(ADIv5_AP_t *ap);
 
-void adiv5_jtag_dp_handler(jtag_dev_t *dev);
+void adiv5_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode);
 int platform_jtag_dp_init(ADIv5_DP_t *dp);
 
 void adiv5_mem_write(ADIv5_AP_t *ap, uint32_t dest, const void *src, size_t len);

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -41,7 +41,7 @@ static uint32_t adiv5_jtagdp_error(ADIv5_DP_t *dp);
 
 static void adiv5_jtagdp_abort(ADIv5_DP_t *dp, uint32_t abort);
 
-void adiv5_jtag_dp_handler(jtag_dev_t *dev)
+void adiv5_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode)
 {
 	ADIv5_DP_t *dp = (void*)calloc(1, sizeof(*dp));
 	if (!dp) {			/* calloc failed: heap exhaustion */
@@ -49,9 +49,9 @@ void adiv5_jtag_dp_handler(jtag_dev_t *dev)
 		return;
 	}
 
-	dp->dev = dev;
+	dp->dp_jd_index = jd_index;
 	if ((PC_HOSTED == 0 ) || (!platform_jtag_dp_init(dp))) {
-		dp->idcode = dev->jd_idcode;
+		dp->idcode = j_idcode;
 		dp->dp_read = fw_adiv5_jtagdp_read;
 		dp->error = adiv5_jtagdp_error;
 		dp->low_access = fw_adiv5_jtagdp_low_access;
@@ -85,11 +85,11 @@ uint32_t fw_adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 
 	request = ((uint64_t)value << 3) | ((addr >> 1) & 0x06) | (RnW?1:0);
 
-	jtag_dev_write_ir(&jtag_proc, dp->dev, APnDP ? IR_APACC : IR_DPACC);
+	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, APnDP ? IR_APACC : IR_DPACC);
 
 	platform_timeout_set(&timeout, 2000);
 	do {
-		jtag_dev_shift_dr(&jtag_proc, dp->dev, (uint8_t*)&response,
+		jtag_dev_shift_dr(&jtag_proc, dp->dp_jd_index, (uint8_t*)&response,
 						  (uint8_t*)&request, 35);
 		ack = response & 0x07;
 	} while(!platform_timeout_is_expired(&timeout) && (ack == JTAGDP_ACK_WAIT));
@@ -106,6 +106,6 @@ uint32_t fw_adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 static void adiv5_jtagdp_abort(ADIv5_DP_t *dp, uint32_t abort)
 {
 	uint64_t request = (uint64_t)abort << 3;
-	jtag_dev_write_ir(&jtag_proc, dp->dev, IR_ABORT);
-	jtag_dev_shift_dr(&jtag_proc, dp->dev, NULL, (const uint8_t*)&request, 35);
+	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_ABORT);
+	jtag_dev_shift_dr(&jtag_proc, dp->dp_jd_index, NULL, (const uint8_t*)&request, 35);
 }

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -51,7 +51,7 @@ void adiv5_jtag_dp_handler(jtag_dev_t *dev)
 
 	dp->dev = dev;
 	if ((PC_HOSTED == 0 ) || (!platform_jtag_dp_init(dp))) {
-		dp->idcode = dev->idcode;
+		dp->idcode = dev->jd_idcode;
 		dp->dp_read = fw_adiv5_jtagdp_read;
 		dp->error = adiv5_jtagdp_error;
 		dp->low_access = fw_adiv5_jtagdp_low_access;

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -39,6 +39,7 @@ int adiv5_swdp_scan(void)
 
 	target_list_free();
 	ADIv5_DP_t *dp = (void*)calloc(1, sizeof(*dp));
+	dp->dp_jd_index = JTAG_MAX_DEVS; /* Tag for BMP_REMOTE */
 	if (!dp) {			/* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return -1;

--- a/src/target/jtag_devs.h
+++ b/src/target/jtag_devs.h
@@ -22,7 +22,7 @@ typedef const struct jtag_dev_descr_s {
 	const uint32_t idcode;
 	const uint32_t idmask;
 	const char * const descr;
-	void (*const handler)(jtag_dev_t *dev);
+	void (*const handler)(uint8_t jd_index, uint32_t j_idcode);
 } jtag_dev_descr_t;
 extern jtag_dev_descr_t dev_descr[];
 

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -188,15 +188,16 @@ int jtag_scan(const uint8_t *irlens)
 				jtag_devs[i].jd_descr = dev_descr[j].descr;
 				/* Call handler to initialise/probe device further */
 				if(dev_descr[j].handler)
-					dev_descr[j].handler(&jtag_devs[i]);
+					dev_descr[j].handler(i, dev_descr[j].idcode);
 				break;
 			}
 
 	return jtag_dev_count;
 }
 
-void jtag_dev_write_ir(jtag_proc_t *jp, jtag_dev_t *d, uint32_t ir)
+void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir)
 {
+	jtag_dev_t *d = &jtag_devs[jd_index];
 	if(ir == d->current_ir) return;
 	for(int i = 0; i < jtag_dev_count; i++)
 		jtag_devs[i].current_ir = -1;
@@ -209,8 +210,9 @@ void jtag_dev_write_ir(jtag_proc_t *jp, jtag_dev_t *d, uint32_t ir)
 	jtagtap_return_idle();
 }
 
-void jtag_dev_shift_dr(jtag_proc_t *jp, jtag_dev_t *d, uint8_t *dout, const uint8_t *din, int ticks)
+void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks)
 {
+	jtag_dev_t *d = &jtag_devs[jd_index];
 	jtagtap_shift_dr();
 	jp->jtagtap_tdi_seq(0, ones, d->dr_prescan);
 	if(dout)

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -94,7 +94,7 @@ int jtag_scan(const uint8_t *irlens)
 			}
 			jtag_devs[jtag_dev_count].ir_len = *irlens;
 			jtag_devs[jtag_dev_count].ir_prescan = j;
-			jtag_devs[jtag_dev_count].dev = jtag_dev_count;
+			jtag_devs[jtag_dev_count].jd_dev = jtag_dev_count;
 			j += *irlens;
 			irlens++;
 			jtag_dev_count++;
@@ -117,7 +117,7 @@ int jtag_scan(const uint8_t *irlens)
 				if(jtag_devs[jtag_dev_count].ir_len == 1) break;
 				jtag_devs[++jtag_dev_count].ir_len = 1;
 				jtag_devs[jtag_dev_count].ir_prescan = j;
-				jtag_devs[jtag_dev_count].dev = jtag_dev_count;
+				jtag_devs[jtag_dev_count].jd_dev = jtag_dev_count;
 			} else jtag_devs[jtag_dev_count].ir_len++;
 			j++;
 		}
@@ -169,9 +169,9 @@ int jtag_scan(const uint8_t *irlens)
 	jtagtap_shift_dr();
 	for(i = 0; i < jtag_dev_count; i++) {
 		if(!jtag_proc.jtagtap_next(0, 1)) continue;
-		jtag_devs[i].idcode = 1;
+		jtag_devs[i].jd_idcode = 1;
 		for(j = 2; j; j <<= 1)
-			if(jtag_proc.jtagtap_next(0, 1)) jtag_devs[i].idcode |= j;
+			if(jtag_proc.jtagtap_next(0, 1)) jtag_devs[i].jd_idcode |= j;
 
 	}
 	DEBUG_INFO("Return to Run-Test/Idle\n");
@@ -181,11 +181,11 @@ int jtag_scan(const uint8_t *irlens)
 	/* Check for known devices and handle accordingly */
 	for(i = 0; i < jtag_dev_count; i++)
 		for(j = 0; dev_descr[j].idcode; j++)
-			if((jtag_devs[i].idcode & dev_descr[j].idmask) ==
+			if((jtag_devs[i].jd_idcode & dev_descr[j].idmask) ==
 			   dev_descr[j].idcode) {
 				jtag_devs[i].current_ir = -1;
 				/* Save description in table */
-				jtag_devs[i].descr = dev_descr[j].descr;
+				jtag_devs[i].jd_descr = dev_descr[j].descr;
 				/* Call handler to initialise/probe device further */
 				if(dev_descr[j].handler)
 					dev_descr[j].handler(&jtag_devs[i]);

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -45,6 +45,6 @@ extern int jtag_dev_count;
 
 void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir);
 void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks);
-
+void jtag_add_device(const int dev_index, const jtag_dev_t *jtag_dev);
 #endif
 

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -27,7 +27,7 @@
 
 typedef struct jtag_dev_s {
 	union {
-		uint8_t dev;
+		uint8_t jd_dev;
 		uint8_t dr_prescan;
 	};
 	uint8_t dr_postscan;
@@ -35,8 +35,8 @@ typedef struct jtag_dev_s {
 	uint8_t ir_len;
 	uint8_t ir_prescan;
 	uint8_t ir_postscan;
-	uint32_t idcode;
-	const char *descr;
+	uint32_t jd_idcode;
+	const char *jd_descr;
 	uint32_t current_ir;
 } jtag_dev_t;
 

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -43,8 +43,8 @@ typedef struct jtag_dev_s {
 extern struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS+1];
 extern int jtag_dev_count;
 
-void jtag_dev_write_ir(jtag_proc_t *jp, jtag_dev_t *dev, uint32_t ir);
-void jtag_dev_shift_dr(jtag_proc_t *jp, jtag_dev_t *dev, uint8_t *dout, const uint8_t *din, int ticks);
+void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir);
+void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks);
 
 #endif
 


### PR DESCRIPTION
With hosted/firmware, when scanning the jtag chain, transfer the jtag device and chain information to the firmware so that the high level commands later have valid information. W/o this information, the firmware crashes.