### PR TITLE
cortexm.c/cortexm_halt_resume: Add some clock cycles to always get CP…

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -835,6 +835,8 @@ static void cortexm_halt_resume(target *t, bool step)
 		target_mem_write32(t, CORTEXM_ICIALLU, 0);
 
 	target_mem_write32(t, CORTEXM_DHCSR, dhcsr);
+	/* Add some clock cycles to get the CPU running again.*/
+	target_mem_read32(t, 0);
 }
 
 static int cortexm_fault_unwind(target *t)


### PR DESCRIPTION
…U going.
Preferered when running with bmp/firmware, on a fresh started device after "mon tar ..., mon s", the device still was left halted also DHCSR had been written. Adding another read as was done with detach made the device continue reliable.