### PR TITLE
Add support for Kinetis K12 and placeholders for other K-series MCUs

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -435,12 +435,14 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		}
 		if (ap->ap_partno == 0x4c3)  /* Cortex-M3 ROM */
 			PROBE(stm32f1_probe); /* Care for STM32F1 clones */
-		else if (ap->ap_partno == 0x471)  { /* Cortex-M0 ROM */
+		else if (ap->ap_partno == 0x471) { /* Cortex-M0 ROM */
 			PROBE(lpc11xx_probe); /* LPC24C11 */
 			PROBE(lpc43xx_probe);
 		}
-		else if (ap->ap_partno == 0x4c4) /* Cortex-M4 ROM */
+		else if (ap->ap_partno == 0x4c4) { /* Cortex-M4 ROM */
 			PROBE(lpc43xx_probe);
+			PROBE(kinetis_probe); /* Older K-series */
+		}
 		/* Info on PIDR of these parts wanted! */
 		PROBE(sam3x_probe);
 		PROBE(lpc15xx_probe);

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -196,7 +196,7 @@ bool kinetis_probe(target *t)
 		kl_gen_add_flash(t, 0x00000000, 0x40000, 0x400, KL_WRITE_LEN);
 		break;
 	case 0x271:
-		switch((sdid>>16)&0x0f){
+		switch((sdid >> 16) & 0x0f) {
 			case 4:
 				t->driver = "KL27x32";
 				target_add_ram(t, 0x1ffff800, 0x0800);
@@ -214,7 +214,7 @@ bool kinetis_probe(target *t)
 		}
 		break;
 	case 0x021: /* KL02 family */
-		switch((sdid>>16) & 0x0f){
+		switch((sdid >> 16) & 0x0f) {
 			case 3:
 				t->driver = "KL02x32";
 				target_add_ram(t, 0x1FFFFC00, 0x400);
@@ -235,7 +235,7 @@ bool kinetis_probe(target *t)
 				break;
 			default:
 				return false;
-			}
+		}
 		break;
 	case 0x031: /* KL03 family */
 		t->driver = "KL03";
@@ -260,6 +260,64 @@ bool kinetis_probe(target *t)
 		target_add_ram(t, 0x20000000,  0x30000);
 		kl_gen_add_flash(t, 0, 0x80000, 0x1000, K64_WRITE_LEN);
 		kl_gen_add_flash(t, 0x80000, 0x80000, 0x1000, K64_WRITE_LEN);
+		break;
+	case 0x000: /* Older K-series */
+		switch(sdid & 0xff0) {
+			case 0x000: /* K10 Family, DIEID=0x0 */
+			case 0x080: /* K10 Family, DIEID=0x1 */
+			case 0x100: /* K10 Family, DIEID=0x2 */
+			case 0x180: /* K10 Family, DIEID=0x3 */
+			case 0x220: /* K11 Family, DIEID=0x4 */
+				return false;
+			case 0x200: /* K12 Family, DIEID=0x4 */
+				switch((fcfg1 >> 24) & 0x0f) {
+					/* K12 Sub-Family Reference Manual, K12P80M50SF4RM, Rev. 4, February 2013 */
+					case 0x7:
+						t->driver = "MK12DX128Vxx5";
+						target_add_ram(t, 0x1fffc000, 0x00004000); /* SRAM_L, 16 KB */
+						target_add_ram(t, 0x20000000, 0x00004000); /* SRAM_H, 16 KB */
+						kl_gen_add_flash(t, 0x00000000, 0x00020000, 0x800, KL_WRITE_LEN); /* P-Flash, 128 KB, 2 KB Sectors */
+						kl_gen_add_flash(t, 0x10000000, 0x00010000, 0x800, KL_WRITE_LEN); /* FlexNVM, 64 KB, 2 KB Sectors */
+						break;
+					case 0x9:
+						t->driver = "MK12DX256Vxx5";
+						target_add_ram(t, 0x1fffc000, 0x00004000); /* SRAM_L, 16 KB */
+						target_add_ram(t, 0x20000000, 0x00004000); /* SRAM_H, 16 KB */
+						kl_gen_add_flash(t, 0x00000000, 0x00040000, 0x800, KL_WRITE_LEN); /* P-Flash, 256 KB, 2 KB Sectors */
+						kl_gen_add_flash(t, 0x10000000, 0x00010000, 0x800, KL_WRITE_LEN); /* FlexNVM, 64 KB, 2 KB Sectors */
+						break;
+					case 0xb:
+						t->driver = "MK12DN512Vxx5";
+						target_add_ram(t, 0x1fff8000, 0x00008000); /* SRAM_L, 32 KB */
+						target_add_ram(t, 0x20000000, 0x00008000); /* SRAM_H, 32 KB */
+						kl_gen_add_flash(t, 0x00000000, 0x00040000, 0x800, KL_WRITE_LEN); /* P-Flash, 256 KB, 2 KB Sectors */
+						kl_gen_add_flash(t, 0x00040000, 0x00040000, 0x800, KL_WRITE_LEN); /* FlexNVM, 256 KB, 2 KB Sectors */
+						break;
+					default:
+						return false;
+				}
+				break;
+			case 0x010: /* K20 Family, DIEID=0x0 */
+			case 0x090: /* K20 Family, DIEID=0x1 */
+			case 0x110: /* K20 Family, DIEID=0x2 */
+			case 0x190: /* K20 Family, DIEID=0x3 */
+			case 0x230: /* K21 Family, DIEID=0x4 */
+			case 0x330: /* K21 Family, DIEID=0x6 */
+			case 0x210: /* K22 Family, DIEID=0x4 */
+			case 0x310: /* K22 Family, DIEID=0x6 */
+			case 0x0a0: /* K30 Family, DIEID=0x1 */
+			case 0x120: /* K30 Family, DIEID=0x2 */
+			case 0x0b0: /* K40 Family, DIEID=0x1 */
+			case 0x130: /* K40 Family, DIEID=0x2 */
+			case 0x0e0: /* K50 Family, DIEID=0x1 */
+			case 0x0f0: /* K51 Family, DIEID=0x1 */
+			case 0x170: /* K53 Family, DIEID=0x2 */
+			case 0x140: /* K60 Family, DIEID=0x2 */
+			case 0x1c0: /* K60 Family, DIEID=0x3 */
+			case 0x1d0: /* K70 Family, DIEID=0x3 */
+			default:
+				return false;
+		}
 		break;
 	default:
 		return false;


### PR DESCRIPTION
This PR adds support for Kinetis K12 and some (optional) initial placeholders for other K-series MCUs using combined `SIM_SDID[DIEID]` and `SIM_SDID[FAMID]` as used by OpenOCD. There are only a few K12 devices so they can be uniquely identified using the existing query for `SIM_FCFG1[PFSIZE]`, but might need to look at additional registers for other K-series chips.

This chip at least reports ARM as designer in the ADIv5 PIDR, so I added `PROBE(kinetis_probe)` to the default condition. I could create a separate probe function for the older K-series if you prefer.

Just got this probe yesterday. It's working great!

```
(gdb) monitor swdp_scan
Target voltage: 3.3V
Available Targets:
No. Att Driver
 1      MK12DX256Vxx5 M4
 2      Kinetis Recovery (MDM-AP)
(gdb) attach 1
Attaching to program: /Users/jbuonagurio/Dev/MinimalTest/K12/build/test.elf, Remote target
0x000035ec in main ()
(gdb) info mem
Using memory regions provided by the target.
Num Enb Low Addr   High Addr  Attrs
0   y  	0x00000000 0x00040000 flash blocksize 0x800 nocache
1   y  	0x10000000 0x10010000 flash blocksize 0x800 nocache
2   y  	0x1fffc000 0x20000000 rw nocache
3   y  	0x20000000 0x20004000 rw nocache
(gdb) load
Loading section .text, size 0xdd74 lma 0x0
Loading section .init, size 0x4 lma 0xdd74
Loading section .fini, size 0x4 lma 0xdd78
Loading section .ARM.exidx, size 0x8 lma 0xdd7c
Loading section .data, size 0x9b8 lma 0xdd84
Start address 0x180, load size 59196
Transfer rate: 5 KB/sec, 924 bytes/write.
(gdb) compare-sections
Section .text, range 0x0 -- 0xdd74: matched.
Section .init, range 0xdd74 -- 0xdd78: matched.
Section .fini, range 0xdd78 -- 0xdd7c: matched.
Section .data, range 0xdd84 -- 0xe73c: matched.
Section .ARM.exidx, range 0xdd7c -- 0xdd84: matched.
```