### PR TITLE
Make possible building 'hosted' without libusb and libftdi

### DIFF
--- a/src/include/general.h
+++ b/src/include/general.h
@@ -74,6 +74,7 @@ static inline void DEBUG_WARN(const char *format, ...)
 	va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);
+    fflush(stderr);
     va_end(ap);
 	return;
 }
@@ -85,9 +86,15 @@ static inline void DEBUG_INFO(const char *format, ...)
 	va_list ap;
     va_start(ap, format);
 	if (cl_debuglevel & BMP_DEBUG_STDOUT)
+	{
 		vfprintf(stdout, format, ap);
+		fflush(stdout);
+	}
 	else
+	{
 		vfprintf(stderr, format, ap);
+		fflush(stderr);
+	}
     va_end(ap);
 	return;
 }
@@ -99,6 +106,7 @@ static inline void DEBUG_GDB(const char *format, ...)
 	va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);
+    fflush(stderr);
     va_end(ap);
 	return;
 }
@@ -111,6 +119,7 @@ static inline void DEBUG_GDB_WIRE(const char *format, ...)
 	va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);
+    fflush(stderr);
     va_end(ap);
 	return;
 }
@@ -122,6 +131,7 @@ static inline void DEBUG_TARGET(const char *format, ...)
 	va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);
+    fflush(stderr);
     va_end(ap);
 	return;
 }
@@ -133,6 +143,7 @@ static inline void DEBUG_PROBE(const char *format, ...)
 	va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);
+    fflush(stderr);
     va_end(ap);
 	return;
 }
@@ -144,6 +155,7 @@ static inline void DEBUG_WIRE(const char *format, ...)
 	va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);
+    fflush(stderr);
     va_end(ap);
 	return;
 }

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -55,6 +55,7 @@ endif
 VPATH += platforms/pc
 SRC += timing.c cl_utils.c utils.c
 SRC += bmp_remote.c remote_swdptap.c remote_jtagtap.c
+SRC += stubs.c
 ifneq ($(HOSTED_BMP_ONLY), 1)
 SRC += libusb_utils.c
 SRC += stlinkv2.c

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -2,6 +2,15 @@ SYS = $(shell $(CC) -dumpmachine)
 CFLAGS += -DENABLE_DEBUG -DPLATFORM_HAS_DEBUG
 CFLAGS +=-I ./target -I./platforms/pc
 
+# Define HOSTED_BMP_ONLY to '1' in order to build the hosted blackmagic
+# executable with support for native BMP probes only. This makes
+# linking against the libftdi and libusb libraries unnecessary. This can
+# be useful to minimize external dependencies, and make building on
+# windows systems easier.
+ifeq ($(HOSTED_BMP_ONLY), 1)
+ CFLAGS  +=  -DHOSTED_BMP_ONLY
+endif
+
 ifneq (, $(findstring linux, $(SYS)))
 SRC += serial_unix.c
 ifeq ($(ASAN), 1)
@@ -24,6 +33,7 @@ LDFLAGS += -framework CoreFoundation
 CFLAGS += -Ihidapi/hidapi
 endif
 
+ifneq ($(HOSTED_BMP_ONLY), 1)
 LDFLAGS += -lusb-1.0
 CFLAGS += $(shell pkg-config --cflags libftdi1)
 LDFLAGS += $(shell pkg-config --libs libftdi1)
@@ -40,11 +50,16 @@ else
   SRC += cmsis_dap.c dap.c
  endif
 endif
+endif
 
 VPATH += platforms/pc
-SRC += timing.c cl_utils.c utils.c libusb_utils.c
-SRC += stlinkv2.c
+SRC += timing.c cl_utils.c utils.c
 SRC += bmp_remote.c remote_swdptap.c remote_jtagtap.c
+ifneq ($(HOSTED_BMP_ONLY), 1)
+SRC += libusb_utils.c
+SRC += stlinkv2.c
 SRC += ftdi_bmp.c libftdi_swdptap.c libftdi_jtagtap.c
 SRC += jlink.c jlink_adiv5_swdp.c jlink_jtagtap.c
+endif
+
 PC_HOSTED = 1

--- a/src/platforms/hosted/Readme.md
+++ b/src/platforms/hosted/Readme.md
@@ -1,5 +1,15 @@
 # PC-Hosted BMP
-Compile in src with "make PROBE_HOST=hosted"
+Compile in src with "make PROBE_HOST=hosted".
+
+The configuration option 'HOSTED_BMP_ONLY=1'
+("make PROBE_HOST=hosted HOSTED_BMP_ONLY=1 make")
+can be used to build the hosted version with support for
+BMP probes only, without libusb and libftdi support.
+This option excludes support for stlink probes, FTDI-based probes,
+CMSIS-DAP probes, and j-link probes, but can be useful in order
+to minimize external dependencies for building the hosted version,
+and make it easier to build on windows systems, where linking
+against the libusb and libftdi libraries is not always straightforward.
 
 ## Description
 PC-hosted BMP run on the PC and compiles as "blackmagic". When started,
@@ -65,6 +75,9 @@ pacman -S mingw-w64-x86_64-libftdi --needed
 pacman -S mingw-w64-x86_64-gcc --needed
 PROBE_HOST=hosted make
 ```
+Alternatively, the "HOSTED_BMP_ONLY=1" option can be used to build the hosted
+version with support for BMP probes only, without the need to link against
+the libusb and libftdi libraries.
 
 To prepare libusb access to the ftdi/stlink/jlink/cmsis-dap devices, run zadig
 https://zadig.akeo.ie/. Choose WinUSB(libusb-1.0).

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -32,23 +32,6 @@
 #include <signal.h>
 
 #include "bmp_remote.h"
-
-bmp_info_t info;
-
-swd_proc_t swd_proc;
-jtag_proc_t jtag_proc;
-
-static	BMP_CL_OPTIONS_t cl_opts;
-
-/* SIGTERM handler. */
-static void sigterm_handler(int sig)
-{
-	(void)sig;
-	exit(0);
-}
-
-
-#ifndef HOSTED_BMP_ONLY
 #include "stlinkv2.h"
 #include "ftdi_bmp.h"
 #include "jlink.h"
@@ -66,6 +49,11 @@ static void sigterm_handler(int sig)
 #define PRODUCT_ID_STLINKV3E     0x374e
 
 #define VENDOR_ID_SEGGER         0x1366
+
+bmp_info_t info;
+
+swd_proc_t swd_proc;
+jtag_proc_t jtag_proc;
 
 static void exit_function(void)
 {
@@ -86,6 +74,13 @@ static void exit_function(void)
 		break;
 	}
 	fflush(stdout);
+}
+
+/* SIGTERM handler. */
+static void sigterm_handler(int sig)
+{
+	(void)sig;
+	exit(0);
 }
 
 static int find_debuggers(	BMP_CL_OPTIONS_t *cl_opts,bmp_info_t *info)
@@ -277,6 +272,11 @@ static int find_debuggers(	BMP_CL_OPTIONS_t *cl_opts,bmp_info_t *info)
 	return (found_debuggers == 1) ? 0 : -1;
 }
 
+static	BMP_CL_OPTIONS_t cl_opts;
+
+void list_known_bmp_devices(void);
+void list_known_bmp_ports(void);
+void print_available_com_ports(void);
 void platform_init(int argc, char **argv)
 {
 	cl_opts.opt_idstring = "Blackmagic PC-Hosted";
@@ -284,11 +284,14 @@ void platform_init(int argc, char **argv)
 	atexit(exit_function);
 	signal(SIGTERM, sigterm_handler);
 	signal(SIGINT, sigterm_handler);
+
+	list_known_bmp_ports();
+	print_available_com_ports();
+
 	int res = libusb_init(&info.libusb_ctx);
 	if (res) {
 		DEBUG_WARN( "Fatal: Failed to get USB context: %s\n",
 				libusb_strerror(res));
-		exit(-1);
 	}
 	if (cl_opts.opt_device) {
 		info.bmp_type = BMP_TYPE_BMP;
@@ -535,106 +538,6 @@ void platform_buffer_flush(void)
 		break;
 	}
 }
-
-#else /* HOSTED_BMP_ONLY */
-
-static void exit_function(void)
-{
-	fflush(stdout);
-}
-
-void platform_init(int argc, char **argv)
-{
-	cl_opts.opt_idstring = "Blackmagic PC-Hosted";
-	cl_init(&cl_opts, argc, argv);
-	atexit(exit_function);
-	signal(SIGTERM, sigterm_handler);
-	signal(SIGINT, sigterm_handler);
-#if defined(_WIN32) || defined(__CYGWIN__)
-	extern void list_known_bmp_devices(void);
-	/* Only list the known BMP probes, and exit. This is a special case for
-	 * windows, when not using libusb, as in this case the list of known
-	 * BMP probes is fetched from the windows registry, and not by using
-	 * libusb. */
-	if (cl_opts.opt_list_only)
-	{
-		list_known_bmp_devices();
-		exit(0);
-	}
-#endif
-	if (serial_open(&cl_opts, cl_opts.opt_serial))
-		exit(-1);
-	remote_init();
-	int ret = -1;
-	if (cl_opts.opt_mode != BMP_MODE_DEBUG) {
-		ret = cl_execute(&cl_opts);
-	} else {
-		gdb_if_init();
-		return;
-	}
-	exit(ret);
-}
-
-int platform_adiv5_swdp_scan(void)
-{
-	return adiv5_swdp_scan();
-}
-
-int platform_swdptap_init(void)
-{
-	return remote_swdptap_init(&swd_proc);
-}
-
-void platform_add_jtag_dev(int i, const jtag_dev_t *jtag_dev)
-{
-	remote_add_jtag_dev(i, jtag_dev);
-}
-
-int platform_jtag_scan(const uint8_t *lrlens)
-{
-	return jtag_scan(lrlens);
-}
-
-int platform_jtagtap_init(void)
-{
-	return remote_jtagtap_init(&jtag_proc);
-}
-
-void platform_adiv5_dp_defaults(ADIv5_DP_t *dp)
-{
-	if (cl_opts.opt_no_hl) {
-		DEBUG_WARN("Not using HL commands\n");
-		return;
-	}
-	return remote_adiv5_dp_defaults(dp);
-}
-
-int platform_jtag_dp_init(ADIv5_DP_t *dp)
-{
-	(void)dp;
-	return 0;
-}
-
-const char *platform_target_voltage(void)
-{
-	return remote_target_voltage();
-}
-
-void platform_srst_set_val(bool assert)
-{
-	return remote_srst_set_val(assert);
-}
-
-bool platform_srst_get_val(void)
-{
-	return remote_srst_get_val();
-}
-
-void platform_buffer_flush(void)
-{
-}
-
-#endif /* HOSTED_BMP_ONLY */
 
 static void ap_decode_access(uint16_t addr, uint8_t RnW)
 {

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -1,6 +1,10 @@
 #ifndef __PLATFORM_H
 #define __PLATFORM_H
 
+#include <libusb-1.0/libusb.h>
+#include "libusb_utils.h"
+#include <libftdi1/ftdi.h>
+
 #include "timing.h"
 
 void platform_buffer_flush(void);
@@ -13,12 +17,6 @@ void platform_buffer_flush(void);
 #define PRODUCT_ID_BMP_BL        0x6017
 #define PRODUCT_ID_BMP           0x6018
 
-#ifndef HOSTED_BMP_ONLY
-
-#include <libusb-1.0/libusb.h>
-#include "libusb_utils.h"
-#include <libftdi1/ftdi.h>
-
 typedef enum bmp_type_s {
 	BMP_TYPE_NONE = 0,
 	BMP_TYPE_BMP,
@@ -28,10 +26,7 @@ typedef enum bmp_type_s {
 	BMP_TYPE_JLINK
 } bmp_type_t;
 
-#endif /* HOSTED_BMP_ONLY */
-
 typedef struct bmp_info_s {
-#ifndef HOSTED_BMP_ONLY
 	bmp_type_t bmp_type;
 	libusb_context *libusb_ctx;
 	struct ftdi_context *ftdic;
@@ -41,7 +36,6 @@ typedef struct bmp_info_s {
 	char dev;
 	char serial[64];
 	char manufacturer[128];
-#endif /* HOSTED_BMP_ONLY */
 	char product[128];
 } bmp_info_t;
 

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -1,13 +1,8 @@
 #ifndef __PLATFORM_H
 #define __PLATFORM_H
 
-#include <libusb-1.0/libusb.h>
-#include "libusb_utils.h"
-#include <libftdi1/ftdi.h>
-
 #include "timing.h"
 
-char *platform_ident(void);
 void platform_buffer_flush(void);
 
 #define PLATFORM_IDENT() "NONE"
@@ -18,6 +13,12 @@ void platform_buffer_flush(void);
 #define PRODUCT_ID_BMP_BL        0x6017
 #define PRODUCT_ID_BMP           0x6018
 
+#ifndef HOSTED_BMP_ONLY
+
+#include <libusb-1.0/libusb.h>
+#include "libusb_utils.h"
+#include <libftdi1/ftdi.h>
+
 typedef enum bmp_type_s {
 	BMP_TYPE_NONE = 0,
 	BMP_TYPE_BMP,
@@ -27,7 +28,10 @@ typedef enum bmp_type_s {
 	BMP_TYPE_JLINK
 } bmp_type_t;
 
+#endif /* HOSTED_BMP_ONLY */
+
 typedef struct bmp_info_s {
+#ifndef HOSTED_BMP_ONLY
 	bmp_type_t bmp_type;
 	libusb_context *libusb_ctx;
 	struct ftdi_context *ftdic;
@@ -37,6 +41,7 @@ typedef struct bmp_info_s {
 	char dev;
 	char serial[64];
 	char manufacturer[128];
+#endif /* HOSTED_BMP_ONLY */
 	char product[128];
 } bmp_info_t;
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -349,7 +349,7 @@ static int stlink_send_recv_retry(uint8_t *txbuf, size_t txsize,
 		if (res == STLINK_ERROR_OK)
 			return res;
 		uint32_t now = platform_time_ms();
-		if (((now - start) > cortexm_wait_timeout) ||
+		if (((now - start) > (uint32_t) cortexm_wait_timeout) ||
 			(res != STLINK_ERROR_WAIT)) {
 			DEBUG_WARN("write_retry failed. ");
 			return res;

--- a/src/platforms/hosted/stubs.c
+++ b/src/platforms/hosted/stubs.c
@@ -1,0 +1,128 @@
+#include <stdint.h>
+#include "platform.h"
+#include "ftdi_bmp.h"
+#include "jlink.h"
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+cable_desc_t cable_desc[1];
+
+int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
+{
+	return -1;
+}
+int jlink_init(bmp_info_t *info)
+{
+	return -1;
+}
+
+int jlink_jtagtap_init(bmp_info_t *info, jtag_proc_t *jtag_proc)
+{
+	return -1;
+}
+
+bool jlink_srst_get_val(bmp_info_t *info) {
+	return false;
+}
+
+void jlink_srst_set_val(bmp_info_t *info, bool assert)
+{
+}
+int jlink_swdp_scan(bmp_info_t *info)
+{
+	return 0;
+}
+const char *jlink_target_voltage(bmp_info_t *info)
+{
+	return "unknown";
+}
+int jtag_scan_stlinkv2(bmp_info_t *info, const uint8_t *irlens)
+{
+	return 0;
+}
+
+void libftdi_buffer_flush(void)
+{
+}
+int libftdi_jtagtap_init(jtag_proc_t *jtag_proc)
+{
+	return -1;
+}
+int libftdi_swdptap_init(swd_proc_t *swd_proc)
+{
+	return -1;
+}
+
+const char *libftdi_target_voltage(void)
+{
+	return 0;
+}
+
+void stlink_adiv5_dp_defaults(ADIv5_DP_t *dp)
+{
+}
+int stlink_enter_debug_swd(bmp_info_t *info, ADIv5_DP_t *dp)
+{
+	return -1;
+}
+int stlink_init(bmp_info_t *info)
+{
+	return -1;
+}
+int stlink_jtag_dp_init(ADIv5_DP_t *dp)
+{
+	return false;
+}
+bool stlink_srst_get_val(void)
+{
+	return false;
+}
+void stlink_srst_set_val(bmp_info_t *info, bool assert)
+{
+}
+const char *stlink_target_voltage(bmp_info_t *info)
+{
+	return "unknown";
+}
+
+void 	libusb_close (libusb_device_handle *dev_handle)
+{
+}
+
+void 	libusb_free_device_list (libusb_device **list, int unref_devices)
+{
+}
+void 	libusb_free_transfer (struct libusb_transfer *transfer)
+{
+}
+
+int 	libusb_get_device_descriptor (libusb_device *dev, struct libusb_device_descriptor *desc)
+{
+	return -1;
+}
+ssize_t 	libusb_get_device_list (libusb_context *ctx, libusb_device ***list)
+{
+	return -1;
+}
+int 	libusb_get_string_descriptor_ascii (libusb_device_handle *dev_handle, uint8_t desc_index, unsigned char *data, int length)
+{
+	return -1;
+}
+int 	libusb_init (libusb_context **context)
+{
+	return -1;
+}
+int 	libusb_open (libusb_device *dev, libusb_device_handle **dev_handle)
+{
+	return -1;
+}
+
+int 	libusb_release_interface (libusb_device_handle *dev_handle, int interface_number)
+{
+	return -1;
+}
+
+const char * 	libusb_strerror (enum libusb_error errcode)
+{
+	return "libusb not linked in";
+}

--- a/src/platforms/pc/cl_utils.c
+++ b/src/platforms/pc/cl_utils.c
@@ -115,21 +115,52 @@ static void bmp_munmap(struct mmap_data *map)
 
 static void cl_help(char **argv, BMP_CL_OPTIONS_t *opt)
 {
+#ifndef HOSTED_BMP_ONLY
 	DEBUG_WARN("%s for: \n", opt->opt_idstring);
 	DEBUG_WARN("\tBMP hosted %s\n\t\tfor ST-Link V2/3, CMSIS_DAP, JLINK and "
 			   "LIBFTDI/MPSSE\n\n", FIRMWARE_VERSION);
+#else
+	DEBUG_WARN("%s for BMP Firmware.\n", opt->opt_idstring);
+#endif /* HOSTED_BMP_ONLY */
 	DEBUG_WARN("Usage: %s [options]\n", argv[0]);
 	DEBUG_WARN("\t-h\t\t: This help.\n");
 	DEBUG_WARN("\t-v[bitmask]\t: Increasing verbosity. Bitmask:\n");
 	DEBUG_WARN("\t\t\t  1 = INFO, 2 = GDB, 4 = TARGET, 8 = PROBE, 16 = WIRE\n");
 	DEBUG_WARN("Probe selection arguments:\n");
-	DEBUG_WARN("\t-d \"path\"\t: Use serial BMP device at \"path\"(Deprecated)\n");
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+	DEBUG_WARN("\t-d \"path\"\t: Use serial device at \"path\" (e.g. \"com5\", \"\\\\.\\com12\")(Deprecated)\\n");
+#else
+	DEBUG_WARN("\t-d \"path\"\t: Use serial device at \"path\"(Deprecated)\\n");
+#endif
+
+#ifndef HOSTED_BMP_ONLY
 	DEBUG_WARN("\t-P <pos>\t: Use debugger found at position <pos>\n");
+#endif /* HOSTED_BMP_ONLY */
 	DEBUG_WARN("\t-n <num>\t: Use target device found at position <num>\n");
+#if defined(_WIN32) || defined(__CYGWIN__)
+  #ifdef HOSTED_BMP_ONLY
+	/* The '-l' option is not documented. It is recycled here for
+	 * the special case of running hosted in windows, with support
+	 * for BMP probes only. */
+	DEBUG_WARN("\t-l\t\t: List serial numbers of known BMP probes.\n"
+		   "\t\t\t  This is useful for getting a probe's serial number,\n"
+		   "\t\t\t  and passing it to the '-s' option\n");
+  #endif /* HOSTED_BMP_ONLY */
+	DEBUG_WARN("\t-s \"serial\"\t: Use BMP probe with serial number \"serial\".\n"
+		   "\t\t\t  This is useful for opening a specific probe,\n"
+		   "\t\t\t  regardless of which serial port number has been\n"
+		   "\t\t\t  assigned to it, which is especially useful if\n"
+		   "\t\t\t  several probes are attached simultaneously\n");
+#else
 	DEBUG_WARN("\t-s \"serial\"\t: Use dongle with (partial) "
 		  "serial number \"serial\"\n");
+#endif
+
+#ifndef HOSTED_BMP_ONLY
 	DEBUG_WARN("\t-c \"string\"\t: Use ftdi dongle with type \"string\"\n");
-	DEBUG_WARN("\t\t Use \"list\" to list available cables\n");
+	DEBUG_WARN("\t\t\t  Use \"list\" to list available cables\n");
+#endif /* HOSTED_BMP_ONLY */
 	DEBUG_WARN("Run mode related options:\n");
 	DEBUG_WARN("\tDefault mode is to start the debug server at :2000\n");
 	DEBUG_WARN("\t-j\t\t: Use JTAG. SWD is default.\n");
@@ -161,10 +192,12 @@ void cl_init(BMP_CL_OPTIONS_t *opt, int argc, char **argv)
 	opt->opt_flash_start = 0xffffffff;
 	while((c = getopt(argc, argv, "eEhHv:d:s:I:c:CnltVta:S:jpP:rR")) != -1) {
 		switch(c) {
+#ifndef HOSTED_BMP_ONLY
 		case 'c':
 			if (optarg)
 				opt->opt_cable = optarg;
 			break;
+#endif /* HOSTED_BMP_ONLY */
 		case 'h':
 			cl_help(argv, opt);
 			break;
@@ -228,10 +261,12 @@ void cl_init(BMP_CL_OPTIONS_t *opt, int argc, char **argv)
 			if (optarg)
 				opt->opt_target_dev = strtol(optarg, NULL, 0);
 			break;
+#ifndef HOSTED_BMP_ONLY
 		case 'P':
 			if (optarg)
 				opt->opt_position = atoi(optarg);
 			break;
+#endif /* HOSTED_BMP_ONLY */
 		case 'S':
 			if (optarg) {
 				char *endptr;


### PR DESCRIPTION
To build the hosted variant of the BMP, without the need to
link against libusb and libftdi, run make with options:
"make PROBE_HOST=hosted HOSTED_BMP_ONLY=yes"

This minimizes external dependencies, and can be useful in
scenarious where access to the libusb and libftdi libraries
is not readily available.

The patch builds successfully on msys2, and on debian, tested with both "HOSTED_BMP_ONLY=yes", and without setting "HOSTED_BMP_ONLY".