### PR TITLE
Switch on the lpc546xx target

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -441,6 +441,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		}
 		else if (ap->ap_partno == 0x4c4) { /* Cortex-M4 ROM */
 			PROBE(lpc43xx_probe);
+			PROBE(lpc546xx_probe);
 			PROBE(kinetis_probe); /* Older K-series */
 		}
 		/* Info on PIDR of these parts wanted! */

--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -140,7 +140,7 @@ bool lpc546xx_probe(target *t)
 	target_add_commands(t, lpc546xx_cmd_list, "Lpc546xx");
 	t->target_options |= CORTEXM_TOPT_INHIBIT_SRST;
 
-	return false;
+	return true;
 }
 
 /* Reset all major systems _except_ debug */


### PR DESCRIPTION
Enable the lpc546xx target. Tested on the LPCXpresso54628 dev board,
able to flash and debug.