### PR TITLE
Add support for STM32F1 clone with new AP_DESIGNER id

### DIFF
--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -98,6 +98,7 @@
 /*LPC845 with designer 501. Strange!? */
 #define AP_DESIGNER_SPECULAR     0x501
 #define AP_DESIGNER_ENERGY_MICRO 0x673
+#define AP_DESIGNER_CS		 0x555
 
 /* AP Control and Status Word (CSW) */
 #define ADIV5_AP_CSW_DBGSWENABLE	(1u << 31)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -387,6 +387,9 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 			target_halt_resume(t, 0);
 		}
 		break;
+	case AP_DESIGNER_CS:
+		PROBE(stm32f1_probe);
+		break;
 	case AP_DESIGNER_STM:
 		PROBE(stm32f1_probe);
 		PROBE(stm32f4_probe);

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -126,6 +126,7 @@ bool stm32f1_probe(target *t)
 	size_t flash_size;
 	size_t block_size = 0x400;
 	switch(t->idcode) {
+	case 0x29b: /* CS clone */
 	case 0x410:  /* Medium density */
 	case 0x412:  /* Low density */
 	case 0x420:  /* Value Line, Low-/Medium density */


### PR DESCRIPTION
This patch adds support for STM32F1 clones that report AP_DESIGNER 0x555 and PartNo 0x29b, reporting STM32F1 (clone) medium density.