### PR TITLE
Probe LPC546xx before LPC43xx

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -442,8 +442,8 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 			PROBE(lpc11xx_probe); /* LPC24C11 */
 			PROBE(lpc43xx_probe);
 		} else if (ap->ap_partno == 0x4c4) { /* Cortex-M4 ROM */
+			PROBE(lpc546xx_probe); /* Probe LPC546xx first to avoid hang */
 			PROBE(lpc43xx_probe);
-			PROBE(lpc546xx_probe);
 			PROBE(kinetis_probe); /* Older K-series */
 		}
 		/* Info on PIDR of these parts wanted! */


### PR DESCRIPTION
When targeting LPC546xx, the adapter fails when probing for LPC43xx and
exits probing without trying LPC546xx. Not sure why that's happening. I
don't have an LPC43xx board to verify this change is OK there. I
verified the LPC546xx behavior is OK after this patch on an
LPCXpresso54628 board.