### PR TITLE
Change the type of 'cortexm_wait_timeout' to unsigned.

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -96,7 +96,7 @@ bool connect_assert_srst;
 #if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
 bool debug_bmp;
 #endif
-long cortexm_wait_timeout = 2000; /* Timeout to wait for Cortex to react on halt command. */
+unsigned cortexm_wait_timeout = 2000; /* Timeout to wait for Cortex to react on halt command. */
 
 int command_process(target *t, char *cmd)
 {

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -22,7 +22,7 @@
 #include "target.h"
 #include "adiv5.h"
 
-extern long cortexm_wait_timeout;
+extern unsigned cortexm_wait_timeout;
 /* Private peripheral bus base address */
 #define CORTEXM_PPB_BASE	0xE0000000
 


### PR DESCRIPTION
It makes sense that the timeout value is unsigned, it also
resolves build errors on some platforms.