### PR TITLE
Add hard reset option to PC hosted platform

### DIFF
--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -333,6 +333,13 @@ void platform_init(int argc, char **argv)
 	default:
 		exit(-1);
 	}
+
+	if (cl_opts.opt_hard_srst) {
+		DEBUG_INFO("hard reset\n");
+		platform_srst_set_val(true);
+		platform_srst_set_val(false);
+	}
+
 	int ret = -1;
 	if (cl_opts.opt_mode != BMP_MODE_DEBUG) {
 		ret = cl_execute(&cl_opts);

--- a/src/platforms/pc/cl_utils.c
+++ b/src/platforms/pc/cl_utils.c
@@ -143,6 +143,7 @@ static void cl_help(char **argv, BMP_CL_OPTIONS_t *opt)
 	DEBUG_WARN("\t-r\t\t: Read flash and write to binary file\n");
 	DEBUG_WARN("\t-p\t\t: Supplies power to the target (where applicable)\n");
 	DEBUG_WARN("\t-R\t\t: Reset device\n");
+	DEBUG_WARN("\t-x\t\t: Hard reset target before other commands\n");
 	DEBUG_WARN("\t-H\t\t: Do not use high level commands (BMP-Remote)\n");
 	DEBUG_WARN("Flash operation modifiers options:\n");
 	DEBUG_WARN("\tDefault action with given file is to write to flash\n");
@@ -159,7 +160,7 @@ void cl_init(BMP_CL_OPTIONS_t *opt, int argc, char **argv)
 	opt->opt_target_dev = 1;
 	opt->opt_flash_size = 16 * 1024 *1024;
 	opt->opt_flash_start = 0xffffffff;
-	while((c = getopt(argc, argv, "eEhHv:d:s:I:c:CnltVta:S:jpP:rR")) != -1) {
+	while((c = getopt(argc, argv, "eEhHv:d:s:I:c:CnltVta:S:jpP:rRx")) != -1) {
 		switch(c) {
 		case 'c':
 			if (optarg)

--- a/src/platforms/pc/cl_utils.h
+++ b/src/platforms/pc/cl_utils.h
@@ -42,6 +42,7 @@ typedef struct BMP_CL_OPTIONS_s {
 	bool opt_tpwr;
 	bool opt_list_only;
 	bool opt_connect_under_reset;
+	bool opt_hard_srst;
 	bool external_resistor_swd;
 	bool opt_no_hl;
 	char *opt_flash_file;


### PR DESCRIPTION
Add an option `-x` to issue a reset pulse on RST before running other
commands. This can help recover a chip that's stuck in Lockup.