### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+﻿---
+Language:        Cpp
+
+BreakBeforeBraces: Linux
+ConstructorInitializerIndentWidth: '8'
+ContinuationIndentWidth: '8'
+IndentWidth: '8'
+TabWidth: '8'
+UseTab: Always
+...


### PR DESCRIPTION
Add a .clang-format specification file. I tried to match as closely as
possible to the existing style, but there are a few exceptions that the
tool doesn't support:

- macro invocation puts brace on the following line (eg `TRY_CATCH`
blocks)
- inline comment wrapping in control blocks without braces:
   ```c
   	// clang-format outputs this:
   	if (connect_assert_srst)
		platform_srst_set_val(
			true); /* will be deasserted after attach */
	// instead of:
	if (connect_assert_srst)
	    platform_srst_set_val(true); /* will be deasserted after attach */
   ```
   this is due to clang-format attempting to enforce 80-character line
   limit

Otherwise the format seems to match pretty closely with the existing
source.