### PR TITLE
Support GD32E23x

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -448,6 +448,8 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 			PROBE(lpc43xx_probe);
 			PROBE(lpc546xx_probe);
 			PROBE(kinetis_probe); /* Older K-series */
+		} else if (ap->ap_partno == 0x4cb) { /* Cortex-M23 ROM */
+			PROBE(gd32f1_probe); /* GD32E23x uses GD32F1 peripherals */
 		}
 		/* Info on PIDR of these parts wanted! */
 		PROBE(sam3x_probe);

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -123,8 +123,10 @@ static void stm32f1_add_flash(target *t,
 bool gd32f1_probe(target *t)
 {
 	uint16_t stored_idcode = t->idcode;
-	// M3 & M4 & riscV only afaik
-	t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfff;
+	if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
+		t->idcode = target_mem_read32(t, DBGMCU_IDCODE_F0) & 0xfff;
+	else
+		t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfff;
 	uint32_t signature= target_mem_read32(t, FLASHSIZE);
 	uint32_t flashSize=signature & 0xFFFF;
 	uint32_t ramSize=signature >>16 ;
@@ -132,11 +134,14 @@ bool gd32f1_probe(target *t)
 	case 0x414:  /* Gigadevice gd32f303 */
 		t->driver = "GD32F3";
 		break;
-	case 0x410:  /* Gigadevice gd32f103 */
-        t->driver = "GD32F1";
+	case 0x410:  /* Gigadevice gd32f103, gd32e230 */
+		if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
+			t->driver = "GD32E230";
+		else
+			t->driver = "GD32F1";
 		break;
 	default:
-        t->idcode = stored_idcode;
+		t->idcode = stored_idcode;
 		return false;
 	}
 	target_add_ram(t, 0x20000000, ramSize*1024);


### PR DESCRIPTION
Adding support for [GigaDevice GD32E230C8T6](https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m23/value-line/gd32e230-series/), which previously showed up as `Unknown ARM Cortex-M Designer 43b Partno 4cb M23` and flash operations would not work. This part series is essentially just a Cortex-M23 core with STM32F1-style peripherals.

The part I was testing with had an idcode of `0x410`, but I'm not sure whether the other [GD32E23x](https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m23/) parts share the same ID or not.