### PR TITLE
Fix building with newer GNU make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -126,8 +126,8 @@ all_platforms:
 		export PROBE_HOST=`basename $$DIRNAME` ;\
 		export CFLAGS=-Werror ;\
 		echo "Building for hardware platform: $$PROBE_HOST" ;\
-		$(MAKE) $(MAKEFLAGS) clean ;\
-		$(MAKE) $(MAKEFLAGS);\
+		$(MAKE) clean ;\
+		$(MAKE);\
 		if [ -f blackmagic.bin ]; then \
 			mv blackmagic.bin artifacts/blackmagic-$$PROBE_HOST.bin ;\
 			echo "<li><a href='blackmagic-$$PROBE_HOST.bin'>$$PROBE_HOST</a></li>"\


### PR DESCRIPTION
More recent versions of GNU make remove the `-` prefix from
`$(MAKEFLAGS)`, which breaks the build:

```bash
 # output truncated to interesting parts
> make -C src --trace all_platforms
set -e ;\
mkdir -p artifacts/v1.7.1-91-g98b4ec5 ;\
echo "<html><body><ul>" > artifacts/index.html ;\
for i in platforms/*/Makefile.inc ; do \
        ...\
        make w --trace --no-print-directory clean ;\
        make w --trace --no-print-directory;\
        ...\
done ;\
echo "</ul></body></html>" >> artifacts/index.html ;\
cp artifacts/*.bin artifacts/v1.7.1-91-g98b4ec5
Building for hardware platform: f4discovery
make[1]: *** No rule to make target 'w'.  Stop.
```

Per the
[documentation](https://www.gnu.org/software/make/manual/html_node/Options_002fRecursion.html),
there's no need to manually apply insert `$(MAKEFLAGS)`, it should be
automatically included when using `$(MAKE)` when recursing.

I tested on my machine (make 4.2.1) and a docker image based on
ubuntu:trusty (make 3.81), both behaved the same (directories were not
printed when recursing by default);