### PR TITLE
add src/artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ blackmagic_upgrade
 *.exe
 *.elf
 .vscode
+.gdb_history
+src/artifacts/


### PR DESCRIPTION
This folder is generated when running `make -C src all_platforms`. Add
it to ignored files.