### PR TITLE
gitattributes: add attributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,40 @@
+# Text for humans
+LICENSE text eol=lf
+HACKING text eol=lf
+COPYING text eol=lf
+UsingSWO text eol=lf
+README.* text eol=lf
+
+# Source code
+Makefile text eol=lf
+*.mk text eol=lf
+*.mak text eol=lf
+*.inc text eol=lf
+*.py text eol=lf
+*.sh text eol=lf
+*.c text eol=lf
+*.S text eol=lf
+*.s text eol=lf
+*.h text eol=lf
+*.ld text eol=lf
+*.yml text eol=lf
+*.rules text eol=lf
+
+# Git control files
+.gitattributes eol=lf
+.gitignore eol=lf
+.gitmodules eol=lf
+
+# Windows source code uses CRLF
+*.vcxproj text eol=crlf
+*.props text eol=crlf
+*.bat text eol=crlf
+*.ps1 text eol=crlf
+*.inf text eol=crlf
+
+# Other binary files
+*.png binary
+*.jpg binary
+*.bin binary
+*.elf binary
+*.bin binary


### PR DESCRIPTION
On different platforms, line endings can differ. Git tries to
intelligently convert source code to match native line endings when
doing a checkout, unless a particular configuration flag is set.

An alternate approach is to create a `.gitattributes` file and manually
specify various types of files. This ensures files are properly handled.
It also prevents git from creating patches that consist of nothing more
than replacing line endings.
