### PR TITLE
Some adjustments for handling the BMP serial number.

### DIFF
--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -395,11 +395,7 @@ static const struct usb_config_descriptor config = {
 	.interface = ifaces,
 };
 
-#if defined(DUSE_ST_SERIAL)
-char serial_no[13];
-#else
-static char serial_no[9];
-#endif
+static char serial_no[13];
 
 #define BOARD_IDENT "Black Magic Probe" PLATFORM_IDENT FIRMWARE_VERSION
 #define DFU_IDENT   "Black Magic Firmware Upgrade" PLATFORM_IDENT FIRMWARE_VERSION

--- a/src/platforms/stm32/serialno.c
+++ b/src/platforms/stm32/serialno.c
@@ -21,8 +21,8 @@
 
 char *serial_no_read(char *s, int max)
 {
-#if defined(STM32F1) || defined(USE_BMP_SERIAL)
-/* Only STM32F103 has no DFU Bootloader. Generate a ID comatible
+#if defined(STM32F1) || defined(USE_ST_SERIAL)
+/* Only STM32F103 has no DFU Bootloader. Generate a ID compatible
  * with the BMP Bootloader since ages.
  */
 	uint32_t *unique_id_p = (uint32_t *)DESIG_UNIQUE_ID_BASE;


### PR DESCRIPTION
Maybe this pull request should not be merged into the master branch as it is.
I got confused with serial number handling, I think I found some issues that are highlighted in this change.

I only did a brief check - `make all_platforms` build cleanly, no other tests done.