### PR TITLE
WIP STM32H750 support

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -199,13 +199,14 @@ static bool stm32h7_attach(target *t)
 	target_mem_map_free(t);
 
 	/* Add RAM to memory map */
+	/* Table 7. Memory map and default device memory area attributes RM 0433, pg 130 */
 	target_add_ram(t, 0x00000000, 0x10000); /* ITCM Ram,  64 k */
 	target_add_ram(t, 0x20000000, 0x20000); /* DTCM Ram, 128 k */
 	target_add_ram(t, 0x24000000, 0x80000); /* AXI Ram,  512 k */
 	target_add_ram(t, 0x30000000, 0x20000); /* AHB SRAM1, 128 k */
-	target_add_ram(t, 0x32000000, 0x20000); /* AHB SRAM2, 128 k */
-	target_add_ram(t, 0x34000000, 0x08000); /* AHB SRAM3,  32 k */
-	target_add_ram(t, 0x38000000, 0x01000); /* AHB SRAM4,  32 k */
+	target_add_ram(t, 0x30020000, 0x20000); /* AHB SRAM2, 128 k */
+	target_add_ram(t, 0x30040000, 0x08000); /* AHB SRAM3,  32 k */
+	target_add_ram(t, 0x38000000, 0x10000); /* AHB SRAM4,  64 k */
 
 	/* Add the flash to memory map. */
 	stm32h7_add_flash(t, 0x8000000, 0x100000, FLASH_SECTOR_SIZE);


### PR DESCRIPTION
@UweBonnes and I were talking earlier, I'm trying to get support working for the STM32H750.

I don't expect to merge this code, just a draft request for some insights.

The memory map had some errors and the h750 only has 1 bank of "user main memory"..

in gdb I load:
```shell
>>> load
Loading section .isr_vector, size 0x298 lma 0x8000000
Loading section .text, size 0xecb0 lma 0x8000298
Loading section .init_array, size 0x18 lma 0x800ef48
Loading section .fini_array, size 0x4 lma 0x800ef60
Loading section .data, size 0xbc lma 0x800ef64
Start address 0x8002190, load size 61472
Transfer rate: 6 KB/sec, 917 bytes/write.
```

the blackmagic host mode shows:

```shell
2 0xe00e3000: 0x00000000 <- does not match preamble (0xB105000D)
3 0xe00e4000: 0x00000000 <- does not match preamble (0xB105000D)
```


when I compare in gdb
```shell
>>> compare-sections 
Section .isr_vector, range 0x8000000 -- 0x8000298: matched.
Ignoring packet error, continuing...
Reply contains invalid hex digit 105
```


here is the output from `blackmagic -t`
```shell
BMP hosted v1.7.1-120-g09c000e-dirty
 for ST-Link V2/3, CMSIS_DAP, JLINK and LIBFTDI/MPSSE
Using 1d50:6018 79A75FA8 Black Sphere Technologies
 Black Magic Probe
Running in Test Mode
Target voltage: 3.3V Volt
Update Firmware to allow to set max SWJ frequency
Device has fixed frequency for SWD
DPIDR 0x6ba02477 (v2 rev6)
Please update BMP firmware for substantial speed increase!
RESET_SEQ succeeded.
TARGETID 04500041
AP   0: IDR=84770001 CFG=00000000 BASE=e00fe003 CSW=43800040
AP#0 IDR = 0x84770001 (AHB-AP var0 rev8)
ROM: Table BASE=0xe00fe000 SYSMEM=0x00000001, designer  20 Partno 450
ROM: Table BASE=0xe00ff000 SYSMEM=0x00000001, designer 43b Partno 4c7
 0 0xe000e000: Generic IP component - Cortex-M4 SCS (System Control Space) (PIDR = 0x04000bb00c  DEVTYPE = 0x00 ARCHID = 0x0000) -> cortexm_probe
CPUID 0x411fc271 (M7 var 1 rev 1)
 1 0xe0001000: Generic IP component - Cortex-M3 DWT (Data Watchpoint and Trace) (PIDR = 0x04000bb002  DEVTYPE = 0x00 ARCHID = 0x0000)
 2 0xe0002000: Generic IP component - Cortex-M7 FBP (Flash Patch and Breakpoint) (PIDR = 0x04000bb00e  DEVTYPE = 0x00 ARCHID = 0x0000)
 3 0xe0000000: Generic IP component - Cortex-M3 ITM (Instrumentation Trace Module) (PIDR = 0x04000bb001  DEVTYPE = 0x00 ARCHID = 0x0000)
 4 Entry 0xfff41002 -> Not present
 5 Entry 0xfff42002 -> Not present
 ROM: Table END
1 0xe0041000: Debug component - Cortex-M7 ETM (Embedded Trace) (PIDR = 0x04001bb975  DEVTYPE = 0x13 ARCHID = 0x4a13)
2 0xe0043000: Debug component - CoreSight CTI (Cross Trigger) (PIDR = 0x04004bb906  DEVTYPE = 0x14 ARCHID = 0x0000)
3 Entry 0x1ff02002 -> Not present
ROM: Table END
AP   1: IDR=84770001 CFG=00000000 BASE=00000002 CSW=43800040
AP#0 IDR = 0x84770001 (AHB-AP var0 rev8)
AP   2: IDR=54770002 CFG=00000000 BASE=e00e0003 CSW=80000040
AP#0 IDR = 0x54770002 (AHB-AP var0 rev5)
ROM: Table BASE=0xe00e0000 SYSMEM=0x00000000, designer  20 Partno 450
0 Entry 0x1002 -> Not present
1 Entry 0x2002 -> Not present
2 0xe00e3000: 0x00000000 <- does not match preamble (0xB105000D)
3 0xe00e4000: 0x00000000 <- does not match preamble (0xB105000D)
4 0xe00e5000: PrimeCell peripheral - System TSGEN (Time Stamp Generator) (PIDR = 0x04001bb101  DEVTYPE = 0x00 ARCHID = 0x0000)
ROM: Table BASE=0xe00f0000 SYSMEM=0x00000000, designer  20 Partno   1
 0 0xe00f1000: Debug component - CoreSight CTI (Cross Trigger) (PIDR = 0x04005bb906  DEVTYPE = 0x14 ARCHID = 0x0000)
 1 Entry 0x2002 -> Not present
 2 0xe00f3000: Debug component - CoreSight CSTF (Trace Funnel) (PIDR = 0x04003bb908  DEVTYPE = 0x12 ARCHID = 0x0000)
 3 0xe00f4000: Debug component - CoreSight TMC (Trace Memory Controller) (PIDR = 0x04001bb961  DEVTYPE = 0x32 ARCHID = 0x0000)
 4 0xe00f5000: Debug component - CoreSight TPIU (Trace Port Interface Unit) (PIDR = 0x04005bb912  DEVTYPE = 0x11 ARCHID = 0x0000)
 5 Entry 0x6002 -> Not present
 6 Entry 0x7002 -> Not present
 7 Entry 0x8002 -> Not present
 ROM: Table END
ROM: Table END
***  1      STM32H7 M7
target idcode 1104
Ram   Start: 0x38000000, length   0x10000
Ram   Start: 0x30040000, length    0x8000
Ram   Start: 0x30020000, length   0x20000
Ram   Start: 0x30000000, length   0x20000
Ram   Start: 0x24000000, length   0x80000
Ram   Start: 0x20000000, length   0x20000
Ram   Start: 0x00000000, length   0x10000
Flash Start: 0x08000000, length   0x20000, blocksize  0x20000
```