### PR TITLE
fixing some memory map errors for stm32h7

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -25,6 +25,13 @@
  *   Reference manual - STM32H7x3 advanced ARM®-based 32-bit MCUs Rev.3
  */
 
+/*
+ * While the ST document (RM 0433) claims that the stm32h750 only has 1 bank
+ * with 1 sector (128k) of user main memory flash (pages 151-152), we were able
+ * to write and successfully verify into other regions in bank 1 and also into
+ * bank 2 (0x0810 0000 as indicated for the other chips).
+ */
+
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"
@@ -199,13 +206,14 @@ static bool stm32h7_attach(target *t)
 	target_mem_map_free(t);
 
 	/* Add RAM to memory map */
+	/* Table 7. Memory map and default device memory area attributes RM 0433, pg 130 */
 	target_add_ram(t, 0x00000000, 0x10000); /* ITCM Ram,  64 k */
 	target_add_ram(t, 0x20000000, 0x20000); /* DTCM Ram, 128 k */
 	target_add_ram(t, 0x24000000, 0x80000); /* AXI Ram,  512 k */
 	target_add_ram(t, 0x30000000, 0x20000); /* AHB SRAM1, 128 k */
-	target_add_ram(t, 0x32000000, 0x20000); /* AHB SRAM2, 128 k */
-	target_add_ram(t, 0x34000000, 0x08000); /* AHB SRAM3,  32 k */
-	target_add_ram(t, 0x38000000, 0x01000); /* AHB SRAM4,  32 k */
+	target_add_ram(t, 0x30020000, 0x20000); /* AHB SRAM2, 128 k */
+	target_add_ram(t, 0x30040000, 0x08000); /* AHB SRAM3,  32 k */
+	target_add_ram(t, 0x38000000, 0x10000); /* AHB SRAM4,  64 k */
 
 	/* Add the flash to memory map. */
 	stm32h7_add_flash(t, 0x8000000, 0x100000, FLASH_SECTOR_SIZE);


### PR DESCRIPTION
@UweBonnes helped me debug the BMP with my stm32h750.
while the stm document (RM 0433) claims that the h750 only has 1 bank with 1 sector (128k) of user main memory flash (pages 151-152), we were able to write and successfully verify into other regions in bank 1 and also into bank 2 (0x0810 0000 as indicated for the other chips).

here is a transcript, I removed the warnings about the preamble not matching
```shell
./src/blackmagic -a 0x08000000 ~/local/src/DaisyExamples/field/KeybrdTest/build/ex_field_keyboard_test.bin 
Flash Write succeeded for 61472 bytes,   26.879 kiB/s

./src/blackmagic -a 0x08000000 -V ~/local/src/DaisyExamples/field/KeyboardTest/build/ex_field_keyboard_test.bin 
Read/Verify succeeded for 61472 bytes,   52.947 kiB/s

./src/blackmagic -a 0x08030000 ~/local/src/DaisyExamples/field/KeyboardTest/build/ex_field_keyboard_test.bin 
Flash Write succeeded for 61472 bytes,   26.985 kiB/s

./src/blackmagic -a 0x08030000 -V ~/local/src/DaisyExamples/field/KeyboardTest/build/ex_field_keyboard_test.bin 
Read/Verify succeeded for 61472 bytes,   52.675 kiB/s

./src/blackmagic -a 0x08100000 ./blob 
Flash Write succeeded for 13 bytes,    0.014 kiB/s

./src/blackmagic -a 0x08100000 -V ./blob 
Read/Verify succeeded for 13 bytes,   13.000 kiB/s

./src/blackmagic -a 0x08000000 -V ~/local/src/DaisyExamples/field/KeyboardTest/build/ex_field_keyboard_test.bin
Read/Verify succeeded for 61472 bytes,   53.734 kiB/s
```

While looking into the docs I noticed that the memory map was incorrect for the h7 series, so these are those fixes.