### PR TITLE
Cortexm prepare

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -383,23 +383,6 @@ static bool cortexm_prepare(ADIv5_AP_t *ap)
 			return false;
 		}
 	}
-	/* Apply device specific settings for successfull Romtable scan
-	 *
-	 * STM32F7 in WFI will not read ROMTABLE when using WFI
-	 */
-	if ((ap->dp->targetid >> 1 & 0x7ff) == 0x20) {
-		uint32_t dbgmcu_cr = 7;
-		uint32_t dbgmcu_cr_addr = 0xE0042004;
-		switch ((ap->dp->targetid >> 16) & 0xfff) {
-		case 0x449:
-		case 0x451:
-		case 0x452:
-			ap->ap_storage = adiv5_mem_read32(ap, dbgmcu_cr_addr);
-			dbgmcu_cr = ap->ap_storage | 7;
-			adiv5_mem_write(ap, dbgmcu_cr_addr, &dbgmcu_cr, sizeof(dbgmcu_cr));
-			break;
-		}
-	}
 	return true;
 }
 

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -196,7 +196,10 @@ char *stm32f4_get_chip_name(uint32_t idcode)
 
 static void stm32f4_detach(target *t)
 {
-	target_mem_write32(t, DBGMCU_CR, t->target_storage);
+	uint32_t dbgmcu_cr = target_mem_read32(t, DBGMCU_CR);
+	dbgmcu_cr &= ~7;
+	dbgmcu_cr |= (t->target_storage & 7);
+	target_mem_write32(t, DBGMCU_CR, dbgmcu_cr);
 	cortexm_detach(t);
 }
 
@@ -232,6 +235,8 @@ static bool stm32f4_attach(target *t)
 	if (!cortexm_attach(t))
 		return false;
 
+	uint32_t dbgmcu_cr = target_mem_read32(t, DBGMCU_CR);
+	target_mem_write32(t,  DBGMCU_CR, dbgmcu_cr | 7);
 	switch(t->idcode) {
 	case ID_STM32F40X:
 		has_ccmram = true;


### PR DESCRIPTION
- Always halt CPU before probing. Is an option needed not to halt?
- For STM32F4/7 always set debug sleep bits with probe and attach
- Restore debug sleep bit on detach to value stored on probe.
- Provide monitor command to inhibit restore to ease next  probe/halt.