### PR TITLE
stm32f1: On ST parts there is no need to read IDCODE again.

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -155,11 +155,6 @@ bool gd32f1_probe(target *t)
 
 bool stm32f1_probe(target *t)
 {
-	uint16_t stored_idcode = t->idcode;
-	if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M0)
-		t->idcode = target_mem_read32(t, DBGMCU_IDCODE_F0) & 0xfff;
-	else
-		t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfff;
 	size_t flash_size;
 	size_t block_size = 0x400;
 	switch(t->idcode) {
@@ -232,7 +227,6 @@ bool stm32f1_probe(target *t)
 		block_size = 0x800;
 		break;
 	default:     /* NONE */
-		t->idcode = stored_idcode;
 		return false;
 	}
 


### PR DESCRIPTION
IDCODE is already known from the Romtable
Probably this has the same effect as #836