### PR TITLE
Cortexm halt

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -377,7 +377,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		target_check_error(t);
 	}
 #define PROBE(x) \
-	do { if ((x)(t)) {target_halt_resume(t, 0); return true;} else target_check_error(t); } while (0)
+	do { if ((x)(t)) {return true;} else target_check_error(t); } while (0)
 
 	switch (ap->ap_designer) {
 	case AP_DESIGNER_FREESCALE:

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -155,6 +155,11 @@ bool gd32f1_probe(target *t)
 
 bool stm32f1_probe(target *t)
 {
+	uint16_t stored_idcode = t->idcode;
+	if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M0)
+		t->idcode = target_mem_read32(t, DBGMCU_IDCODE_F0) & 0xfff;
+	else
+		t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfff;
 	size_t flash_size;
 	size_t block_size = 0x400;
 	switch(t->idcode) {
@@ -227,6 +232,7 @@ bool stm32f1_probe(target *t)
 		block_size = 0x800;
 		break;
 	default:     /* NONE */
+		t->idcode = stored_idcode;
 		return false;
 	}
 


### PR DESCRIPTION
Revert last patch mangling up all STM32F0.  Fix #836 by always halting CPU before romtable scan. Release from halt only once after scan