### PR TITLE
Put null terminating characters when scanning for BMP probes on linux

### DIFF
--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -178,6 +178,7 @@ static int scan_linux_id(char *name, char *type, char *version, char  *serial)
 		return -1;
 	}
 	strncpy(type, name, p - name);
+	type[p - name] = 0;
 	name = p;
 	while (*name != 'v')
 		name++;
@@ -191,6 +192,7 @@ static int scan_linux_id(char *name, char *type, char *version, char  *serial)
 		return -1;
 	}
 	strncpy(version, name, p - name);
+	version[p - name] = 0;
 	name = p;
 	while (*name == '_')
 		name++;
@@ -204,6 +206,7 @@ static int scan_linux_id(char *name, char *type, char *version, char  *serial)
 		return -1;
 	}
 	strncpy(serial, name, p - name);
+	serial[p - name] = 0;
 	return 0;
 }
 


### PR DESCRIPTION
This patch puts null terminating characters for the 'type',
'version', and 'serial' strings extracted from blackmagic probe
id strings on linux systems.

This output from blackmagic hosted has been observed with two BMP probes connected (stlink-v3, and an ordinary stlink):
```
 1: 0055003B3038510D34333935, Black Sphere Technologies, Black Magic Probe (STLINK-V3�Y�%), v1.7.1-144-g9d0b7838eb
 2: E3C89DF43038510D34333935, Black Sphere Technologies, Black Magic Probe (STLINK-V3�Y�%), v1.6-rc0-955-ge3fd12eb
```
With this patch applied, the output changes to:
```
 1: 0055003B3038510D34333935, Black Sphere Technologies, Black Magic Probe (STLINK-V3), v1.7.1-144-g9d0b7838
 2: E3C89DF4, Black Sphere Technologies, Black Magic Probe (STLINK), v1.6-rc0-955-ge3fd12eb
```