### PR TITLE
STM32G49/G4A Category 4 devices support

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -415,7 +415,7 @@ static int stm32f4_flash_erase(struct target_flash *f, target_addr addr,
 	/* Check for error */
 	sr = target_mem_read32(t, FLASH_SR);
 	if(sr & SR_ERROR_MASK) {
-		DEBUG_WARN("stm32f4 flash erase: sr error: 0x%" PRIu32 "\n", sr);
+		DEBUG_WARN("stm32f4 flash erase: sr error: 0x%" PRIx32 "\n", sr);
 		return -1;
 	}
 	return 0;

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -648,7 +648,8 @@ static bool stm32l4_cmd_option(target *t, int argc, char *argv[])
 		len = 11;
 		for (int i = 0; i < len; i++)
 			values[i] = g4_values[i];
-	} else if (t->idcode == ID_STM32G49) { /* G4 cat 4*/
+	} else if ((t->idcode == ID_STM32G43) || (t->idcode == ID_STM32G49)) {
+		/* G4 cat 2 and 4 (single bank) */
 		i2offset = g4_i2offset;
 		len = 6;
 		for (int i = 0; i < len; i++)

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -507,7 +507,7 @@ static int stm32l4_flash_write(struct target_flash *f,
 	} while (sr & FLASH_SR_BSY);
 
 	if(sr & FLASH_SR_ERROR_MASK) {
-		DEBUG_WARN("stm32l4 flash write error: sr 0x%" PRIu32 "\n", sr);
+		DEBUG_WARN("stm32l4 flash write error: sr 0x%" PRIx32 "\n", sr);
 		return -1;
 	}
 	return 0;


### PR DESCRIPTION
Hello,

This little PR for the support of the G4 category 4 devices (up to 512 kiB single bank).

I also bring a little "PRIu32 -> PRIx32" fixup.

Additionally, G43/44 now conform to G49/G4A option bytes. Their option bytes support were probably broken as they previously took L4 values so Securable Memory Area was not tunable.

CAUTION: I have not tested this new G4 chip as I do not have any at hand!
This contribution is based on the documentation only.
