### PR TITLE
modify target stm32f4.c to enable register R/W from debugger for the …

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -300,6 +300,7 @@ static bool stm32f4_attach(target *t)
 		target_add_ram(t, 0x00000000, 0x4000);  /* 16 k ITCM Ram */
 		target_add_ram(t, 0x20000000, 0x20000); /* 128 k DTCM Ram */
 		target_add_ram(t, 0x20020000, 0x60000); /* 384 k Ram */
+                target_add_ram(t, 0x40000000, 0x50000); /* peripheral registers */
 		if (dual_bank) {
 			uint32_t optcr;
 			optcr = target_mem_read32(t, FLASH_OPTCR);
@@ -309,6 +310,7 @@ static bool stm32f4_attach(target *t)
 		if (has_ccmram)
 			target_add_ram(t, 0x10000000, 0x10000); /* 64 k CCM Ram*/
 		target_add_ram(t, 0x20000000, 0x50000);     /* 320 k RAM */
+                target_add_ram(t, 0x40000000, 0x50000); /* peripheral registers */
 		if (dual_bank) {
 			use_dual_bank = true;
 			if (max_flashsize < 0x800) {


### PR DESCRIPTION
…stm32xx families

With this patch, one can observe peripheral registers which is very useful when debugging drivers.