### PR TITLE
Clean static from probe

### DIFF
--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -344,7 +344,10 @@ static void samx5x_add_flash(target *t, uint32_t addr, size_t length,
 	target_add_flash(t, f);
 }
 
-static char samx5x_variant_string[60];
+struct samx5x_priv_s {
+	char samx5x_variant_string[60];
+};
+
 bool samx5x_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
@@ -370,20 +373,25 @@ bool samx5x_probe(target *t)
 	bool protected = (ctrlstat & SAMX5X_STATUSB_PROT);
 
 	/* Part String */
+	struct samx5x_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
+	t->target_storage = (void*)priv_storage;
+
 	if (protected) {
-		snprintf(samx5x_variant_string, sizeof(samx5x_variant_string),
+		snprintf(priv_storage->samx5x_variant_string,
+				 sizeof(priv_storage->samx5x_variant_string),
 			 "Microchip SAM%c%d%c%dA (rev %c) (PROT=1)",
 			 samx5x.series_letter, samx5x.series_number,
 			 samx5x.pin, samx5x.mem, samx5x.revision);
 	} else {
-		snprintf(samx5x_variant_string, sizeof(samx5x_variant_string),
+		snprintf(priv_storage->samx5x_variant_string,
+				 sizeof(priv_storage->samx5x_variant_string),
 			 "Microchip SAM%c%d%c%dA (rev %c)",
 			 samx5x.series_letter, samx5x.series_number,
 			 samx5x.pin, samx5x.mem, samx5x.revision);
 	}
 
 	/* Setup Target */
-	t->driver = samx5x_variant_string;
+	t->driver = priv_storage->samx5x_variant_string;
 	t->reset = samx5x_reset;
 
 	if (protected) {

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -114,6 +114,10 @@ struct target_s {
 	uint16_t t_designer;
 	uint16_t idcode;
 	void *target_storage;
+	union {
+		bool unsafe_enabled;
+		bool ke04_mode;
+	};
 
 	struct target_ram *ram;
 	struct target_flash *flash;


### PR DESCRIPTION
Some target probe functions used static RAM variables. This will fail if several of the  same targets are in the JTAG/SWD chain and unnecessary remove RAM form the RAM pool if the target is not used. If the target needs more than one word, it allocated priv_storage is used. For a single needed word, one word has been added to the target structure as a union to allow decent naming. 