### PR TITLE
Revert "cmsis_dap: Always write full reportsize + 1 buffers"

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -66,7 +66,7 @@ int dap_init(bmp_info_t *info)
 	 */
 	if ((info->vid == 0x1fc9) && (info->pid == 0x0132)) {
 		DEBUG_WARN("Blacklist\n");
-		report_size = 64;
+		report_size = 64 + 1;
 	}
 	handle = hid_open(info->vid, info->pid,  (serial[0]) ? serial : NULL);
 	if (!handle)
@@ -99,11 +99,6 @@ int dap_init(bmp_info_t *info)
 		DEBUG_INFO(", SWO_MANCHESTER");
 	if (dap_caps & 0x10)
 		DEBUG_INFO(", Atomic Cmds");
-	size = dap_info(DAP_INFO_PACKET_SIZE, hid_buffer, sizeof(hid_buffer));
-	if (size) {
-		report_size = hid_buffer[0];
-		DEBUG_INFO(", Reportsize %d", hid_buffer[0]);
-	}
 	DEBUG_INFO("\n");
 	return 0;
 }
@@ -176,17 +171,16 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 	char cmd = data[0];
 	int res;
 
-	memset(hid_buffer, 0, report_size + 1);
+	memset(hid_buffer, 0xff, report_size + 1);
 
+	hid_buffer[0] = 0x00; // Report ID??
 	memcpy(&hid_buffer[1], data, rsize);
 
 	DEBUG_WIRE("cmd :   ");
 	for(int i = 0; (i < 32) && (i < rsize + 1); i++)
 		DEBUG_WIRE("%02x.",	hid_buffer[i]);
 	DEBUG_WIRE("\n");
-	/* Write must be as long as we expect the result, at least
-	 * for Dappermime 20210213 */
-	res = hid_write(handle, hid_buffer, report_size + 1);
+	res = hid_write(handle, hid_buffer, rsize + 1);
 	if (res < 0) {
 		DEBUG_WARN( "Error: %ls\n", hid_error(handle));
 		exit(-1);
@@ -196,14 +190,14 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 		DEBUG_WARN( "debugger read(): %ls\n", hid_error(handle));
 		exit(-1);
 	}
-	DEBUG_WIRE("res %2d: ", res);
-	for(int i = 0; (i < 16) && (i < res + 1); i++)
-		DEBUG_WIRE("%02x.",	hid_buffer[i]);
-	DEBUG_WIRE("\n");
 	if (hid_buffer[0] != cmd) {
 		DEBUG_WARN("cmd %02x invalid response received %02x\n",
 				   cmd, hid_buffer[0]);
 	}
+	DEBUG_WIRE("cmd res:");
+	for(int i = 0; (i < 16) && (i < size + 1); i++)
+		DEBUG_WIRE("%02x.",	hid_buffer[i]);
+	DEBUG_WIRE("\n");
 	if (size)
 		memcpy(data, &hid_buffer[1], (size < res) ? size : res);
 	return res;

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -198,7 +198,7 @@ void dap_connect(bool jtag)
 //-----------------------------------------------------------------------------
 void dap_disconnect(void)
 {
-	uint8_t buf[65];
+	uint8_t buf[1];
 
 	buf[0] = ID_DAP_DISCONNECT;
 	dbg_dap_cmd(buf, sizeof(buf), 1);
@@ -213,7 +213,7 @@ uint32_t dap_swj_clock(uint32_t clock)
 {
 	if (clock == 0)
 		return swj_clock;
-	uint8_t buf[65];
+	uint8_t buf[5];
 	buf[0] = ID_DAP_SWJ_CLOCK;
 	buf[1] = clock & 0xff;
 	buf[2] = (clock >> 8) & 0xff;
@@ -254,7 +254,7 @@ void dap_swd_configure(uint8_t cfg)
 //-----------------------------------------------------------------------------
 int dap_info(int info, uint8_t *data, int size)
 {
-	uint8_t buf[32];
+	uint8_t buf[256];
 	int rsize;
 
 	buf[0] = ID_DAP_INFO;
@@ -781,4 +781,44 @@ void dap_swdptap_seq_out_parity(uint32_t MS, int ticks)
 	dbg_dap_cmd(buf, 1, sizeof(buf));
 	if (buf[0])
 		DEBUG_WARN("dap_swdptap_seq_out error\n");
+}
+
+#define SWD_SEQUENCE_IN 0x80
+uint32_t dap_swdptap_seq_in(int ticks)
+{
+	uint8_t buf[5] = {
+		ID_DAP_SWD_SEQUENCE,
+		1,
+		ticks + SWD_SEQUENCE_IN
+	};
+	dbg_dap_cmd(buf, 2 + ((ticks + 7) >> 3), 3);
+	uint32_t res = 0;
+	int len = (ticks + 7) >> 3;
+	while (len--) {
+		res <<= 8;
+		res += buf[len + 1];
+	}
+	return res;
+}
+
+bool dap_swdptap_seq_in_parity(uint32_t *ret, int ticks)
+{
+	(void)ticks;
+	uint8_t buf[8] = {
+		ID_DAP_SWD_SEQUENCE,
+		1,
+		33 + SWD_SEQUENCE_IN,
+	};
+	dbg_dap_cmd(buf, 7, 4);
+	uint32_t res = 0;
+	int len = 4;
+	while (len--) {
+		res <<= 8;
+		res += buf[len + 1];
+	}
+	*ret = res;
+	unsigned int parity = __builtin_parity(res) & 1;
+	parity ^= (buf[5] % 1);
+	DEBUG_WARN("Res %08" PRIx32" %d\n", *ret, parity & 1);
+	return (!parity & 1);
 }


### PR DESCRIPTION
This reverts commit 61e237ec87c525876817e72fc82ce28b2a4951ae.
This makes a CMSIS-DAP probe with version < 1.2 work again on DP V1 devices.
Status of other combination unknown:
    DP  V1 V2 V2/Multidrop
Probe
<  1.2  ok ok --
>= 1.2   ? ?  ?