### PR TITLE
RP2040 fixes

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -661,8 +661,8 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 		return;
 	}
 	DEBUG_INFO("DPIDR 0x%08" PRIx32 " (v%d %srev%d)\n", dp->idcode,
-			   (dp->idcode >> 12) & 0xf,
-			   (dp->idcode & 0x10000) ? "MINDP " : "", dp->idcode >> 28);
+			   (uint8_t)((dp->idcode >> 12) & 0xf),
+			   (dp->idcode & 0x10000) ? "MINDP " : "", (uint16_t)(dp->idcode >> 28));
 	volatile uint32_t ctrlstat = 0;
 #if PC_HOSTED  == 1
 	platform_adiv5_dp_defaults(dp);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -328,7 +328,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		break;
 	default:
 		if (ap->ap_designer != AP_DESIGNER_ATMEL) /* Protected Atmel device?*/{
-			DEBUG_WARN("Unexpected CortexM CPUID partno %04x\n", cpuid_partno);
+			DEBUG_WARN("Unexpected CortexM CPUID partno %04" PRIx32 "\n", cpuid_partno);
 		}
 	}
 	DEBUG_INFO("CPUID 0x%08" PRIx32 " (%s var %" PRIx32 " rev %" PRIx32 ")\n",

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -131,14 +131,14 @@ static bool rp_rom_call(target *t, uint32_t *regs, uint32_t cmd,
 	target_halt_resume(t, false);
 	if (!timeout)
 		return false;
-	DEBUG_INFO("Call cmd %04x\n", cmd);
+	DEBUG_INFO("Call cmd %04" PRIx32 "\n", cmd);
 	platform_timeout to;
 	platform_timeout_set(&to, timeout);
 	do {
 		if (timeout > 400)
 			tc_printf(t, "\b%c", spinner[spinindex++ % 4]);
 		if (platform_timeout_is_expired(&to)) {
-			DEBUG_WARN("RP Run timout %d ms reached: ", timeout);
+			DEBUG_WARN("RP Run timout %d ms reached: ", (int)timeout);
 			break;
 		}
 	} while (!target_halt_poll(t, NULL));
@@ -146,7 +146,7 @@ static bool rp_rom_call(target *t, uint32_t *regs, uint32_t cmd,
 	target_regs_read(t, dbg_regs);
 	bool ret = ((dbg_regs[REG_PC] &~1) != (ps->_debug_trampoline_end & ~1));
 	if (ret) {
-		DEBUG_WARN("rp_rom_call cmd %04x failed, PC %08" PRIx32 "\n",
+		DEBUG_WARN("rp_rom_call cmd %04" PRIx32 " failed, PC %08" PRIx32 "\n",
 				   cmd, dbg_regs[REG_PC]);
 	}
 	return ret;
@@ -181,7 +181,7 @@ static int rp_flash_erase(struct target_flash *f, target_addr addr,
 		DEBUG_WARN("Unaligned len\n");
 		len = (len + 0xfff) & ~0xfff;
 	}
-	DEBUG_INFO("Erase addr %08" PRIx32 " len 0x%" PRIx32 "\n", addr, len);
+	DEBUG_INFO("Erase addr %08" PRIx32 " len 0x%" PRIx32 "\n", addr, (uint32_t)len);
 	target *t = f->t;
 	rp_flash_prepare(t);
 	struct rp_priv_s *ps = (struct rp_priv_s*)t->target_storage;
@@ -236,7 +236,7 @@ static int rp_flash_erase(struct target_flash *f, target_addr addr,
 int rp_flash_write(struct target_flash *f,
                     target_addr dest, const void *src, size_t len)
 {
-	DEBUG_INFO("RP Write %08" PRIx32 " len 0x%" PRIx32 "\n", dest, len);
+	DEBUG_INFO("RP Write %08" PRIx32 " len 0x%" PRIx32 "\n", dest, (uint32_t)len);
 	if ((dest & 0xff) || (len & 0xff)) {
 		DEBUG_WARN("Unaligned erase\n");
 		return -1;

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -283,8 +283,12 @@ int rp_flash_write(struct target_flash *f,
 		ps->regs[0] = dest;
 		ps->regs[1] = SRAM_START;
 		ps->regs[2] = chunksize;
+		/* Loading takes 3 ms per 256 byte page
+		 * however it takes much longer if the XOSC is not enabled
+		 * so lets give ourselves a little bit more time (x10)
+		 */
 		ret |= rp_rom_call(t, ps->regs, ps->flash_range_program,
-					(3 *  chunksize) >> 8); /* 3 ms per 256 byte page */
+					(3 *  chunksize * 10) >> 8);
 		if (ret) {
 			DEBUG_WARN("Write failed!\n");
 			break;


### PR DESCRIPTION
Various fixes for the rp2040 target:
- Firstly fixing some casting errors in debug calls causing build errors for the native probe.
- Added `rp_flash_resume` method for added stability after erase or load commands.
- Added more debug logging for RP2040 target.
- Increased timeout for `flash_range_program` command when XOSC has not been enabled.
- Increased spinner timeout to 500ms (fixes #875)