### PR TITLE
Add nRF51 erase UICR command and fix some warnings

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -436,27 +436,27 @@ handle_v_packet(char *packet, int plen)
 	} else if (!strncmp(packet, "vRun", 4)) {
 		/* Parse command line for get_cmdline semihosting call */
 		char cmdline[83];
-		char *pbuf = cmdline;
+		char *pcmdline = cmdline;
 		char *tok = packet + 4;
 		if (*tok == ';') tok++;
 		*cmdline='\0';
 		while(*tok != '\0') {
 			if(strlen(cmdline)+3 >= sizeof(cmdline)) break;
 			if (*tok == ';') {
-				*pbuf++=' ';
-				*pbuf='\0';
+				*pcmdline++=' ';
+				*pcmdline='\0';
 				tok++;
 				continue;
 			}
 			if (isxdigit(*tok) && isxdigit(*(tok+1))) {
-				unhexify(pbuf, tok, 2);
-				if ((*pbuf == ' ') || (*pbuf == '\\')) {
-					*(pbuf+1)=*pbuf;
-					*pbuf++='\\';
+				unhexify(pcmdline, tok, 2);
+				if ((*pcmdline == ' ') || (*pcmdline == '\\')) {
+					*(pcmdline+1)=*pcmdline;
+					*pcmdline++='\\';
 				}
-				pbuf++;
+				pcmdline++;
 				tok+=2;
-				*pbuf='\0';
+				*pcmdline='\0';
 				continue;
 			}
 			break;

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -21,7 +21,9 @@
 #ifndef __GENERAL_H
 #define __GENERAL_H
 
-#define _GNU_SOURCE
+#if !defined(_GNU_SOURCE)
+# define _GNU_SOURCE
+#endif
 #if !defined(__USE_MINGW_ANSI_STDIO)
 # define __USE_MINGW_ANSI_STDIO 1
 #endif

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -63,14 +63,14 @@ enum BMP_DEBUG {
 #  define DEBUG_WARN printf
 #  define DEBUG_INFO printf
 # else
-#  define DEBUG_WARN(...)
-#  define DEBUG_INFO(...)
+#  define DEBUG_WARN(...) do {} while(0)
+#  define DEBUG_INFO(...) do {} while(0)
 # endif
-# define DEBUG_GDB(...)
-# define DEBUG_TARGET(...)
-# define DEBUG_PROBE(...)
-# define DEBUG_WIRE(...)
-# define DEBUG_GDB_WIRE(...)
+# define DEBUG_GDB(...) do {} while(0)
+# define DEBUG_TARGET(...) do {} while(0)
+# define DEBUG_PROBE(...) do {} while(0)
+# define DEBUG_WIRE(...) do {} while(0)
+# define DEBUG_GDB_WIRE(...) do {} while(0)
 #else
 # include <stdarg.h>
 extern int cl_debuglevel;

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -59,9 +59,12 @@ enum BMP_DEBUG {
  * BMP PC-Hosted is the preferred way. Printing DEBUG_WARN
  * and DEBUG_INFO is kept for comptibiluty.
  */
+# if !defined(PLATFORM_PRINTF)
+#  define PLATFORM_PRINTF printf
+# endif
 # if defined(ENABLE_DEBUG)
-#  define DEBUG_WARN printf
-#  define DEBUG_INFO printf
+#  define DEBUG_WARN PLATFORM_PRINTF
+#  define DEBUG_INFO PLATFORM_PRINTF
 # else
 #  define DEBUG_WARN(...) do {} while(0)
 #  define DEBUG_INFO(...) do {} while(0)

--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -51,7 +51,7 @@ static int cdcacm_gdb_dtr = 1;
 
 static void cdcacm_set_modem_state(usbd_device *dev, int iface, bool dsr, bool dcd);
 
-static const struct usb_device_descriptor dev = {
+static const struct usb_device_descriptor dev_desc = {
 	.bLength = USB_DT_DEVICE_SIZE,
 	.bDescriptorType = USB_DT_DEVICE,
 	.bcdUSB = 0x0200,
@@ -551,7 +551,7 @@ void cdcacm_init(void)
 
 	serial_no_read(serial_no);
 
-	usbdev = usbd_init(&USB_DRIVER, &dev, &config, usb_strings,
+	usbdev = usbd_init(&USB_DRIVER, &dev_desc, &config, usb_strings,
 			    sizeof(usb_strings)/sizeof(char *),
 			    usbd_control_buffer, sizeof(usbd_control_buffer));
 

--- a/src/platforms/stm32/dfucore.c
+++ b/src/platforms/stm32/dfucore.c
@@ -63,7 +63,7 @@ static struct {
 } prog;
 static uint8_t current_error;
 
-const struct usb_device_descriptor dev = {
+const struct usb_device_descriptor dev_desc = {
 	.bLength = USB_DT_DEVICE_SIZE,
 	.bDescriptorType = USB_DT_DEVICE,
 	.bcdUSB = 0x0200,
@@ -293,7 +293,7 @@ void dfu_init(const usbd_driver *driver)
 {
 	get_dev_unique_id(serial_no);
 
-	usbdev = usbd_init(driver, &dev, &config,
+	usbdev = usbd_init(driver, &dev_desc, &config,
 			   usb_strings, 4,
 			   usbd_control_buffer, sizeof(usbd_control_buffer));
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -334,7 +334,7 @@ static bool cortexm_prepare(ADIv5_AP_t *ap)
 	uint32_t dhcsr_ctl = CORTEXM_DHCSR_DBGKEY |	CORTEXM_DHCSR_C_DEBUGEN |
 		CORTEXM_DHCSR_C_HALT;
 	uint32_t dhcsr_valid = CORTEXM_DHCSR_S_HALT | CORTEXM_DHCSR_C_DEBUGEN;
-#ifdef PLATFORM_HAS_DEBUG
+#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
 	uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t dhcsr;

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -125,12 +125,12 @@ int adiv5_swdp_scan(uint32_t targetid)
 			initial_dp->seq_out(0xE79E, 16); /* 0b0111100111100111 */
 			dp_line_reset(initial_dp);
 			initial_dp->fault = 0;
-			volatile struct exception e;
-			TRY_CATCH (e, EXCEPTION_ALL) {
+			volatile struct exception e2;
+			TRY_CATCH (e2, EXCEPTION_ALL) {
 				idcode = initial_dp->low_access(initial_dp, ADIV5_LOW_READ,
 									  ADIV5_DP_IDCODE, 0);
 			}
-			if (e.type) {
+			if (e2.type) {
 				DEBUG_WARN("No usable DP found\n");
 				return -1;
 			}

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -526,7 +526,7 @@ bool cortexm_attach(target *t)
 		platform_timeout timeout;
 		platform_timeout_set(&timeout, 1000);
 		while (1) {
-			uint32_t dhcsr = target_mem_read32(t, CORTEXM_DHCSR);
+			dhcsr = target_mem_read32(t, CORTEXM_DHCSR);
 			if (!(dhcsr & CORTEXM_DHCSR_S_RESET_ST))
 				break;
 			if (platform_timeout_is_expired(&timeout)) {
@@ -572,8 +572,8 @@ static void cortexm_regs_read(target *t, void *data)
 		for(i = 0; i < sizeof(regnum_cortex_m) / 4; i++)
 			*regs++ = base_regs[regnum_cortex_m[i]];
 		if (t->target_options & TOPT_FLAVOUR_V7MF)
-			for(size_t t = 0; t < sizeof(regnum_cortex_mf) / 4; t++)
-			*regs++ = ap->dp->ap_reg_read(ap, regnum_cortex_mf[t]);
+			for(i = 0; i < sizeof(regnum_cortex_mf) / 4; i++)
+				*regs++ = ap->dp->ap_reg_read(ap, regnum_cortex_mf[i]);
 	}
 #else
 	if (0) {}

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -31,6 +31,7 @@ static int nrf51_flash_write(struct target_flash *f,
                              target_addr dest, const void *src, size_t len);
 
 static bool nrf51_cmd_erase_all(target *t, int argc, const char **argv);
+static bool nrf51_cmd_erase_uicr(target *t, int argc, const char **argv);
 static bool nrf51_cmd_read_hwid(target *t, int argc, const char **argv);
 static bool nrf51_cmd_read_fwid(target *t, int argc, const char **argv);
 static bool nrf51_cmd_read_deviceid(target *t, int argc, const char **argv);
@@ -41,6 +42,7 @@ static bool nrf51_cmd_read(target *t, int argc, const char **argv);
 
 const struct command_s nrf51_cmd_list[] = {
 	{"erase_mass", (cmd_handler)nrf51_cmd_erase_all, "Erase entire flash memory"},
+	{"erase_uicr", (cmd_handler)nrf51_cmd_erase_uicr, "Erase UICR registers"},
 	{"read", (cmd_handler)nrf51_cmd_read, "Read device parameters"},
 	{NULL, NULL, NULL}
 };
@@ -235,6 +237,31 @@ static bool nrf51_cmd_erase_all(target *t, int argc, const char **argv)
 
 	/* Erase all */
 	target_mem_write32(t, NRF51_NVMC_ERASEALL, 1);
+
+	/* Poll for NVMC_READY */
+	while (target_mem_read32(t, NRF51_NVMC_READY) == 0)
+		if(target_check_error(t))
+			return false;
+
+	return true;
+}
+
+static bool nrf51_cmd_erase_uicr(target *t, int argc, const char **argv)
+{
+	(void)argc;
+	(void)argv;
+	tc_printf(t, "erase..\n");
+
+	/* Enable erase */
+	target_mem_write32(t, NRF51_NVMC_CONFIG, NRF51_NVMC_CONFIG_EEN);
+
+	/* Poll for NVMC_READY */
+	while (target_mem_read32(t, NRF51_NVMC_READY) == 0)
+		if(target_check_error(t))
+			return false;
+
+	/* Erase UICR */
+	target_mem_write32(t, NRF51_NVMC_ERASEUICR, 1);
 
 	/* Poll for NVMC_READY */
 	while (target_mem_read32(t, NRF51_NVMC_READY) == 0)

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -248,7 +248,7 @@ bool sam3x_probe(target *t)
 	case CHIPID_CIDR_ARCH_SAM4SDC | CHIPID_CIDR_EPROC_CM4:
 		t->driver = "Atmel SAM4S";
 		target_add_ram(t, 0x20000000, 0x400000);
-		size_t size = sam_flash_size(cidr);
+		size = sam_flash_size(cidr);
 		if (size <= 0x80000) {
 			/* Smaller devices have a single bank */
 			sam4_add_flash(t, SAM4S_EEFC_BASE(0), 0x400000, size);

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -386,7 +386,7 @@ static bool stm32f1_cmd_erase_mass(target *t, int argc, const char **argv)
 			if(target_check_error(t))
 				return false;
 		/* Check for error */
-		uint16_t sr = target_mem_read32(t, FLASH_SR + FLASH_BANK2_OFFSET);
+		sr = target_mem_read32(t, FLASH_SR + FLASH_BANK2_OFFSET);
 		if ((sr & SR_ERROR_MASK) || !(sr & SR_EOP))
 			return false;
 	}

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -384,9 +384,9 @@ static int stm32f4_flash_erase(struct target_flash *f, target_addr addr,
 	stm32f4_flash_unlock(t);
 
 	enum align psize = ALIGN_WORD;
-	for (struct target_flash *f = t->flash; f; f = f->next) {
-		if (f->write == stm32f4_flash_write) {
-			psize = ((struct stm32f4_flash *)f)->psize;
+	for (struct target_flash *currf = t->flash; currf; currf = currf->next) {
+		if (currf->write == stm32f4_flash_write) {
+			psize = ((struct stm32f4_flash *)currf)->psize;
 		}
 	}
 	while(len) {

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -276,7 +276,7 @@ int target_flash_done(target *t)
 		if (tmp)
 			return tmp;
 		if (f->done) {
-			int tmp = f->done(f);
+			tmp = f->done(f);
 			if (tmp)
 				return tmp;
 		}


### PR DESCRIPTION
Hi!

I'm trying to get another open source project (https://github.com/vedderb/bldc) that integrates black magic probe to more closely follow the latest version. To minimize the changes it would be nice to get a few fixes from there included in upstream. It's mostly compiler warnings due to a different set of compiler flags being used, but there is also one new command for the nRF5x.

Let me know if I should change something!