### PR TITLE
adiv5: Recover from bad CIDR access (#832)

### DIFF
--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -418,7 +418,9 @@ static void dfu_detach_complete(usbd_device *dev, struct usb_setup_data *req)
 	platform_request_boot();
 
 	/* Reset core to enter bootloader */
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
 	scb_reset_core();
+#endif
 }
 
 static enum usbd_request_return_codes  cdcacm_control_request(usbd_device *dev,

--- a/src/platforms/stm32/serialno.c
+++ b/src/platforms/stm32/serialno.c
@@ -40,7 +40,7 @@ char *serial_no_read(char *s)
 	uint16_t *uid = (uint16_t *)DESIG_UNIQUE_ID_BASE;
 # if defined(STM32F4) || defined(STM32F7)
 	int offset = 3;
-# elif defined(STM32L0) || defined(STM32F3)
+# elif defined(STM32L0) ||  defined(STM32F0) || defined(STM32F3)
 	int offset = 5;
 # endif
 	sprintf(s, "%04X%04X%04X",

--- a/src/remote.c
+++ b/src/remote.c
@@ -144,6 +144,7 @@ void remotePacketProcessSWD(uint8_t i, char *packet)
 		if (i==2) {
 			remote_dp.dp_read = firmware_swdp_read;
 			remote_dp.low_access = firmware_swdp_low_access;
+			remote_dp.abort = firmware_swdp_abort;
 			swdptap_init(&remote_dp);
 			_respond(REMOTE_RESP_OK, 0);
 		} else {
@@ -194,6 +195,7 @@ void remotePacketProcessJTAG(uint8_t i, char *packet)
     case REMOTE_INIT: /* JS = initialise ============================= */
 		remote_dp.dp_read = fw_adiv5_jtagdp_read;
 		remote_dp.low_access = fw_adiv5_jtagdp_low_access;
+		remote_dp.abort = adiv5_jtagdp_abort;
 		jtagtap_init();
 		_respond(REMOTE_RESP_OK, 0);
 		break;

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -310,4 +310,5 @@ uint32_t fw_adiv5_jtagdp_read(ADIv5_DP_t *dp, uint16_t addr);
 uint32_t firmware_swdp_error(ADIv5_DP_t *dp);
 
 void firmware_swdp_abort(ADIv5_DP_t *dp, uint32_t abort);
+void adiv5_jtagdp_abort(ADIv5_DP_t *dp, uint32_t abort);
 #endif


### PR DESCRIPTION
E.g. STM32WLE5 is the same chip as the dual core STM32WL55. The base register
for the AP of the second core is still valid on the WLE, but romtable access
fails. Proper recovery is needed. This should fix #832