### PR TITLE
adiv5/low_access: Wait long enough that at least one full timer tick …

### DIFF
--- a/src/include/general.h
+++ b/src/include/general.h
@@ -164,5 +164,11 @@ static inline void DEBUG_WIRE(const char *format, ...)
 #undef MAX
 #define MAX(x, y)  (((x) > (y)) ? (x) : (y))
 
+#if !defined(SYSTICKHZ)
+# define SYSTICKHZ 100
+#endif
+#define SYSTICKMS (1000 / SYSTICKHZ)
+#define MORSECNT ((SYSTICKHZ / 10) - 1)
+
 #endif
 

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -10,6 +10,8 @@ void platform_buffer_flush(void);
 #define SET_IDLE_STATE(x)
 #define SET_RUN_STATE(x)
 
+#define SYSTICKHZ 1000
+
 #define VENDOR_ID_BMP            0x1d50
 #define PRODUCT_ID_BMP_BL        0x6017
 #define PRODUCT_ID_BMP           0x6018

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -25,9 +25,6 @@
 #include <libopencm3/cm3/systick.h>
 #include <libopencm3/lm4f/usb.h>
 
-#define SYSTICKHZ	100
-#define SYSTICKMS	(1000 / SYSTICKHZ)
-
 #define PLL_DIV_80MHZ	5
 #define PLL_DIV_25MHZ	16
 

--- a/src/timing.c
+++ b/src/timing.c
@@ -21,10 +21,12 @@
 
 void platform_timeout_set(platform_timeout *t, uint32_t ms)
 {
+	if (ms <= SYSTICKMS)
+		ms = SYSTICKMS;
 	t->time = platform_time_ms() + ms;
 }
 
 bool platform_timeout_is_expired(platform_timeout *t)
 {
-	return platform_time_ms() >= t->time;
+	return platform_time_ms() > t->time;
 }


### PR DESCRIPTION
…is waited

for an OK response

Programming STM32F103 failed random with the 20 ms timeout.

Firmware only ticks at 10 hertz, so the sequence "low_access",  "set timeout",
"send out 8 bit command", "read 3 bit result" when reading "wait" and timer
increment tick happening in that sequence will already hits the timeout even
so only mininal time has elapsed.