### PR TITLE
stm32f4x1 blackpillv2

### DIFF
--- a/src/platforms/f4discovery/Makefile.inc
+++ b/src/platforms/f4discovery/Makefile.inc
@@ -8,8 +8,15 @@ CFLAGS += -Istm32/include -mcpu=cortex-m4 -mthumb \
 	-DSTM32F4 -I../libopencm3/include \
 	-Iplatforms/stm32
 
+ifeq ($(BLACKPILL), 1)
+LINKER_SCRIPT=platforms/stm32/blackpillv2.ld
+CFLAGS += -DBLACKPILL=1
+else
+LINKER_SCRIPT=platforms/stm32/f4discovery.ld
+endif
+
 LDFLAGS_BOOT = -lopencm3_stm32f4 \
-	-Wl,-T,platforms/stm32/f4discovery.ld -nostartfiles -lc -lnosys \
+	-Wl,-T,$(LINKER_SCRIPT) -nostartfiles -lc -lnosys \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m4 -Wl,-gc-sections \
 	-mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 	-L../libopencm3/lib

--- a/src/platforms/f4discovery/Readme.md
+++ b/src/platforms/f4discovery/Readme.md
@@ -11,3 +11,55 @@ PC6: TDO/TRACESWO<br>
 
 PC1: TRST<br>
 PC8: SRST<br>
+
+# Alternate build for stm32f401 stm32f411 MiniF4 aka BlackPillV2 boards.
+
+https://github.com/WeActTC/MiniSTM32F4x1
+
+## Connections:
+
+* JTAG/SWD
+   * PA1: TDI
+   * PA13: TMS/SWDIO
+   * PA14: TCK/SWCLK
+   * PB3: TDO/TRACESWO
+   * PB5: TRST
+   * PB4: SRST
+
+* USB USART
+   * PB6: USART1 TX (usbuart_xxx)
+   * PB7: USART1 RX (usbuart_xxx)
+
+* +3V3.
+   * PB8 - turn on IRLML5103 transistor
+
+How to Build
+========================================
+```
+cd blackmagic
+make clean
+make PROBE_HOST=f4discovery BLACKPILL=1
+```
+
+How to Flash with dfu
+========================================
+* After build:
+ * 1) `apt install dfu-util`
+ * 2) Force the F4 into system bootloader mode by jumpering "BOOT0" to "3V3" and "PB2/BOOT1" to "GND" and reset (RESET button). System bootloader should appear.
+ * 3) `dfu-util -a 0 --dfuse-address 0x08000000 -D blackmagic.bin`
+
+To exit from dfu mode press a "key" and "reset", release reset. BMP firmware should appear
+
+
+10 pin male from pins
+========================================
+
+| PB3/TDO  | PB7/RX      | PB8/TX     | X          | PA1/TDI |
+| -------- | ----------- | ---------- | ---------- | ------- |
+| PB4/SRST | +3V3/PB8 SW | PA13/SWDIO | PA14/SWCLK | GND     |
+
+SWJ frequency setting
+====================================
+https://github.com/blacksphere/blackmagic/pull/783#issue-529197718
+
+`mon freq 900k` helps at most

--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -37,20 +37,32 @@
 #include <libopencm3/cm3/systick.h>
 #include <libopencm3/cm3/cortex.h>
 
+#ifdef BLACKPILL
+#include <libopencm3/usb/dwc/otg_fs.h>
+#endif
+
+
 jmp_buf fatal_error_jmpbuf;
 extern char _ebss[];
 
 void platform_init(void)
 {
 	volatile uint32_t *magic = (uint32_t *)_ebss;
-	/* Check the USER button*/
+	/* Enable GPIO peripherals */
 	rcc_periph_clock_enable(RCC_GPIOA);
+	rcc_periph_clock_enable(RCC_GPIOC);
+#ifdef BLACKPILL
+	rcc_periph_clock_enable(RCC_GPIOB);
+#else
+	rcc_periph_clock_enable(RCC_GPIOD);
+#endif
+	/* Check the USER button*/
 	if (gpio_get(GPIOA, GPIO0) ||
-	   ((magic[0] == BOOTMAGIC0) && (magic[1] == BOOTMAGIC1))) {
+		((magic[0] == BOOTMAGIC0) && (magic[1] == BOOTMAGIC1)))
+	{
 		magic[0] = 0;
 		magic[1] = 0;
 		/* Assert blue LED as indicator we are in the bootloader */
-		rcc_periph_clock_enable(RCC_GPIOD);
 		gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT,
 						GPIO_PUPD_NONE, LED_BOOTLOADER);
 		gpio_set(LED_PORT, LED_BOOTLOADER);
@@ -58,44 +70,65 @@ void platform_init(void)
 		   As we just come out of reset, no other deinit is needed!*/
 		rcc_periph_clock_enable(RCC_SYSCFG);
 		SYSCFG_MEMRM &= ~3;
-		SYSCFG_MEMRM |=  1;
+		SYSCFG_MEMRM |= 1;
 		scb_reset_core();
 	}
-
+#ifdef BLACKPILL
+	rcc_clock_setup_pll(&rcc_hse_25mhz_3v3[RCC_CLOCK_3V3_84MHZ]);
+#else
 	rcc_clock_setup_pll(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
+#endif
 
 	/* Enable peripherals */
 	rcc_periph_clock_enable(RCC_OTGFS);
-	rcc_periph_clock_enable(RCC_GPIOC);
-	rcc_periph_clock_enable(RCC_GPIOD);
 	rcc_periph_clock_enable(RCC_CRC);
 
 	/* Set up USB Pins and alternate function*/
-	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE,  GPIO9 | GPIO11 | GPIO12);
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO9 | GPIO11 | GPIO12);
 	gpio_set_af(GPIOA, GPIO_AF10, GPIO9 | GPIO10 | GPIO11 | GPIO12);
 
-	GPIOC_OSPEEDR &=~0xF30;
+#ifdef BLACKPILL
+	GPIOA_OSPEEDR &= 0x3C00000C;
+	GPIOA_OSPEEDR |= 0x28000008;
+#else
+	GPIOC_OSPEEDR &= ~0xF30;
 	GPIOC_OSPEEDR |= 0xA20;
+#endif
+
 	gpio_mode_setup(JTAG_PORT, GPIO_MODE_OUTPUT,
-			GPIO_PUPD_NONE,
-			TCK_PIN | TDI_PIN);
+					GPIO_PUPD_NONE,
+					TCK_PIN | TDI_PIN);
 	gpio_mode_setup(JTAG_PORT, GPIO_MODE_INPUT,
-			GPIO_PUPD_NONE, TMS_PIN);
+					GPIO_PUPD_NONE, TMS_PIN);
 	gpio_set_output_options(JTAG_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ,
 							TCK_PIN | TDI_PIN | TMS_PIN);
 	gpio_mode_setup(TDO_PORT, GPIO_MODE_INPUT,
-			GPIO_PUPD_NONE,
-			TDO_PIN);
+					GPIO_PUPD_NONE,
+					TDO_PIN);
 	gpio_set_output_options(TDO_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ,
-							 TDO_PIN| TMS_PIN);
+							TDO_PIN | TMS_PIN);
 
 	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT,
-			GPIO_PUPD_NONE,
-			LED_UART | LED_IDLE_RUN | LED_ERROR | LED_BOOTLOADER);
+					GPIO_PUPD_NONE,
+					LED_IDLE_RUN | LED_ERROR | LED_BOOTLOADER);
+
+	gpio_mode_setup(LED_PORT_UART, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_UART);
+
+#ifdef PLATFORM_HAS_POWER_SWITCH
+	gpio_set(PWR_BR_PORT, PWR_BR_PIN);
+	gpio_mode_setup(PWR_BR_PORT, GPIO_MODE_OUTPUT,
+					GPIO_PUPD_NONE,
+					PWR_BR_PIN);
+#endif
 
 	platform_timing_init();
 	usbuart_init();
 	cdcacm_init();
+#ifdef BLACKPILL
+	// https://github.com/libopencm3/libopencm3/pull/1256#issuecomment-779424001
+	OTG_FS_GCCFG |= OTG_GCCFG_NOVBUSSENS | OTG_GCCFG_PWRDWN;
+	OTG_FS_GCCFG &= ~(OTG_GCCFG_VBUSBSEN | OTG_GCCFG_VBUSASEN);
+#endif
 }
 
 void platform_srst_set_val(bool assert) { (void)assert; }
@@ -108,8 +141,20 @@ const char *platform_target_voltage(void)
 
 void platform_request_boot(void)
 {
-	uint32_t *magic = (uint32_t *) &_ebss;
+	uint32_t *magic = (uint32_t *)&_ebss;
 	magic[0] = BOOTMAGIC0;
 	magic[1] = BOOTMAGIC1;
 	scb_reset_system();
 }
+
+#ifdef PLATFORM_HAS_POWER_SWITCH
+bool platform_target_get_power(void)
+{
+	return !gpio_get(PWR_BR_PORT, PWR_BR_PIN);
+}
+
+void platform_target_set_power(bool power)
+{
+	gpio_set_val(PWR_BR_PORT, PWR_BR_PIN, !power);
+}
+#endif

--- a/src/platforms/f4discovery/platform.h
+++ b/src/platforms/f4discovery/platform.h
@@ -31,6 +31,55 @@
 #include <setjmp.h>
 
 #define PLATFORM_HAS_TRACESWO
+#ifdef BLACKPILL
+#define PLATFORM_IDENT "(F4Discovery/BlackPillV2) "
+/* Important pin mappings for STM32 implementation:
+        * JTAG/SWD
+                * PA1: TDI<br>
+                * PA13: TMS/SWDIO<br>
+                * PA14: TCK/SWCLK<br>
+                * PB3: TDO/TRACESWO<br>
+                * PB5: TRST<br>
+                * PB4: SRST<br>
+        * USB USART
+                * PB6: USART1 TX
+                * PB7: USART1 RX
+        * +3V3
+                * PB8 - turn on IRLML5103 transistor
+        * Force DFU mode button: PA0
+ */
+
+/* Hardware definitions... */
+#define JTAG_PORT GPIOA
+#define TDI_PORT JTAG_PORT
+#define TMS_PORT JTAG_PORT
+#define TCK_PORT JTAG_PORT
+#define TDO_PORT GPIOB
+#define TDI_PIN GPIO1
+#define TMS_PIN GPIO13
+#define TCK_PIN GPIO14
+#define TDO_PIN GPIO3
+
+#define SWDIO_PORT JTAG_PORT
+#define SWCLK_PORT JTAG_PORT
+#define SWDIO_PIN TMS_PIN
+#define SWCLK_PIN TCK_PIN
+
+#define TRST_PORT GPIOB
+#define TRST_PIN GPIO5
+#define SRST_PORT GPIOB
+#define SRST_PIN GPIO4
+
+#define PWR_BR_PORT GPIOB
+#define PWR_BR_PIN GPIO8
+
+#define LED_PORT GPIOC
+#define LED_PORT_UART GPIOA
+#define LED_UART GPIO1
+#define LED_IDLE_RUN GPIO15
+#define LED_ERROR GPIO14
+#define LED_BOOTLOADER GPIO13
+#else
 #define PLATFORM_IDENT "(F4Discovery) "
 
 /* Important pin mappings for STM32 implementation:
@@ -78,6 +127,8 @@
 #define LED_IDLE_RUN	GPIO13
 #define LED_ERROR	GPIO14
 #define LED_BOOTLOADER	GPIO15
+#endif
+
 #define BOOTMAGIC0 0xb007da7a
 #define BOOTMAGIC1 0xbaadfeed
 

--- a/src/platforms/stm32/blackpillv2.ld
+++ b/src/platforms/stm32/blackpillv2.ld
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the libopenstm32 project.
+ *
+ * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 96K
+}
+
+/* Include the common ld script from libopenstm32. */
+INCLUDE cortex-m-generic.ld


### PR DESCRIPTION
@UweBonnes 
> I am not to happy to add new platforms that do not show new capabilities. They need to be compiled for every test and if basic changes are needed in all platforms, I do not have a reference part. Furthermore, the F4 lacks USB endpoints. A variant of the F4 disco, e.g. "make PROBE_HOST=f4discovery BLACKPILL=1" leaving the f4discovery intact would however be accaptable.

+