### PR TITLE
Reset error LED after successful attach to target

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -284,6 +284,8 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 			else if(last_target) {
 				cur_target = target_attach(last_target,
 						           &gdb_controller);
+				if(cur_target)
+					morse(NULL, false);
 				target_reset(cur_target);
 			}
 			break;
@@ -428,9 +430,10 @@ handle_v_packet(char *packet, int plen)
 	if (sscanf(packet, "vAttach;%08lx", &addr) == 1) {
 		/* Attach to remote target processor */
 		cur_target = target_attach_n(addr, &gdb_controller);
-		if(cur_target)
+		if(cur_target) {
+			morse(NULL, false);
 			gdb_putpacketz("T05");
-		else
+		} else
 			gdb_putpacketz("E01");
 
 	} else if (!strncmp(packet, "vRun", 4)) {
@@ -470,12 +473,13 @@ handle_v_packet(char *packet, int plen)
 			cur_target = target_attach(last_target,
 						   &gdb_controller);
 
-                        /* If we were able to attach to the target again */
-                        if (cur_target) {
+			/* If we were able to attach to the target again */
+			if (cur_target) {
 				target_set_cmdline(cur_target, cmdline);
-                        	target_reset(cur_target);
-                        	gdb_putpacketz("T05");
-                        } else	gdb_putpacketz("E01");
+				target_reset(cur_target);
+				morse(NULL, false);
+				gdb_putpacketz("T05");
+			} else	gdb_putpacketz("E01");
 
 		} else	gdb_putpacketz("E01");
 

--- a/src/morse.c
+++ b/src/morse.c
@@ -64,7 +64,7 @@ void morse(const char *msg, char repeat)
 		DEBUG_WARN("%s\n", msg);
 	(void) repeat;
 #else
-morse_msg = morse_ptr = msg;
+	morse_msg = morse_ptr = msg;
 	morse_repeat = repeat;
 #endif
 }


### PR DESCRIPTION
When the BMP looses connection to the target MCU (for example, after accidentally redefining the SWCLK or SWDIO pin to GPIO or another function), the red LED of the BMP starts blinking in a morse code pattern ("TARGET LOST").

This pull request resets the LED after successfully re-attaching to the target (or attaching to some other target).