### PR TITLE
Escape '*' in responses of the Remote Serial Protocol

### DIFF
--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -158,7 +158,7 @@ void gdb_putpacket(const char *packet, int size)
 			else
 				DEBUG_GDB_WIRE("\\x%02X", c);
 #endif
-			if((c == '$') || (c == '#') || (c == '}')) {
+			if((c == '$') || (c == '#') || (c == '}') || (c == '*')) {
 				gdb_if_putchar('}', 0);
 				gdb_if_putchar(c ^ 0x20, 0);
 				csum += '}' + (c ^ 0x20);


### PR DESCRIPTION
Escape '*' in responses of the Remote Serial Protocol, to avoid that it is interpreted as the start of an RLE sequence.
Fixes #915.