### PR TITLE
Avoid power conflict, test VREF before enabling target power

### DIFF
--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -37,7 +37,9 @@ void platform_timeout_set(platform_timeout *t, uint32_t ms);
 bool platform_timeout_is_expired(platform_timeout *t);
 void platform_delay(uint32_t ms);
 
+#define POWER_CONFLICT_THRESHOLD	5 /* in 0.1V, so 5 stands for 0.5V */
 extern bool connect_assert_srst;
+uint32_t platform_target_voltage_sense(void);
 const char *platform_target_voltage(void);
 int platform_hwversion(void);
 void platform_srst_set_val(bool assert);


### PR DESCRIPTION
Refuse the "monitor tpwr enable" command (with an error message) if a voltage is sensed on VREF. This decreases the chance for a power conflict (when both the BMP and the target power the VREF pin, possibly with a different voltage).

For example, if 2.5V is sensed on the VCC/VREF pins and "monitor tpwr enable" is issued, this patch keeps power disabled and replies "Power conflict, power not enabled."

Caveat #1: I put the threshold for detecting external power on 0.5V. So if VREF is powered with 0.4V, "monintor tpwr enable" will proceed. The value of 0.5V is a bit arbitrary; I want to be sure it is above the noise level.

Caveat #2: This patch does not protect against "monitor tpwr enable" been given first and external power (on VREF) being applied afterwards. This case will (hopefully) be handled in a subsequent PR.

Other note: When you use hosted "blackmagic -t -p" and external power is detected, the reply is:
```
platform_target_set_power failed, error 0
Powering up device unimplemented or failed
```
Maybe we should allocate a specific error number for this case.