### PR TITLE
hosted/dap: Copy command buffer in wait/retry loop

### DIFF
--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -323,10 +323,14 @@ static void dap_line_reset(void)
 
 static uint32_t wait_word(uint8_t *buf, int size, int len, uint8_t *dp_fault)
 {
+	uint8_t cmd_copy[len];
+	memcpy(cmd_copy, buf, len);
 	do {
 		dbg_dap_cmd(buf, size, len);
 		if (buf[1] < DAP_TRANSFER_WAIT)
 			break;
+		if (buf[1] == DAP_TRANSFER_WAIT)
+			memcpy(buf, cmd_copy, len);
 	} while (buf[1] == DAP_TRANSFER_WAIT);
 
 	if (buf[1] > DAP_TRANSFER_WAIT) {


### PR DESCRIPTION
The same buffer is used for both command and response, causing part of the command to be overwritten before it's retried. Solve this by saving and restoring a copy of the command before retrying.

Also included a commit marking some inline functions as static to fix compile errors due to symbol conflicts when the header is included in multiple translation units.