### PR TITLE
STM32G0 OTP area programming and hosted monitor command allowed as preliminary action

### DIFF
--- a/src/platforms/pc/cl_utils.c
+++ b/src/platforms/pc/cl_utils.c
@@ -510,6 +510,8 @@ int cl_execute(BMP_CL_OPTIONS_t *opt)
 			unsigned int flashed = target_flash_write(t, opt->opt_flash_start,
 													  map.data, map.size);
 			/* Buffered write cares for padding*/
+			if (!flashed)
+				flashed = target_flash_done(t);
 			if (flashed) {
 				DEBUG_WARN("Flashing failed!\n");
 				res = -1;
@@ -518,7 +520,6 @@ int cl_execute(BMP_CL_OPTIONS_t *opt)
 				DEBUG_INFO("Success!\n");
 			}
 		}
-		target_flash_done(t);
 		uint32_t end_time = platform_time_ms();
 		DEBUG_WARN("Flash Write succeeded for %d bytes, %8.3f kiB/s\n",
 			   (int)map.size, (((map.size * 1.0)/(end_time - start_time))));


### PR DESCRIPTION
This feature enables programming the 1024 bytes length OTP area on STM32G0 series.
It makes use of the `irreversible` command already existing to prevent setting RDP level 2.
This PR suggests allowing `monitor` commands from hosted as preliminary action (main action preserved). There is null backward incompatibility.

Typical usage, best used from hosted:
```shell
$ ./blackmagic -M "irreversible enable" -a 0x1FFF73E0 otp_8bytes.bin 
Irreversible operations: enabled
Flash Write succeeded for 8 bytes,    1.143 kiB/s
$ ./blackmagic -r -a 0x1FFF7000 -S 0x400 bla.bin && hexdump bla.bin 
Read/Verify succeeded for 1024 bytes,   78.769 kiB/s
0000000 ffff ffff ffff ffff ffff ffff ffff ffff
*
00003e0 aabb aabb ccdd ccdd ffff ffff ffff ffff
00003f0 ffff ffff ffff ffff ffff ffff ffff ffff
0000400
$ ./blackmagic -a 0x1FFF73D8 otp_8bytes.bin 
Irreversible operations disabled
Flashing failed!
```
Any multiple of 8 bytes can be programmed as well, at any empty 8-bytes aligned address.

Detailed test report regarding backward compatibility of `monitor` hosted commands:
Without -M monitor command:
```shell
$ ./blackmagic -E
<no output, successfully erased>
$ ./blackmagic
Listening on TCP: 2000
$ ./blackmagic -r -a 0x08000000 -S 0x10 bla.bin
Read/Verify succeeded for 16 bytes,   16.000 kiB/s
$ ./blackmagic firmware.bin
Flash Write succeeded for 8 bytes,    0.105 kiB/s
```
With -M monitor command:
```shell
$ ./blackmagic -M "option" -E
usage: monitor option erase
usage: monitor option write <addr> <val> [<addr> <val>]...
0x40022020: 0xDFFFE1AA
...
0x40022080: 0x00000000
<Then erase operation takes some time>
$ ./blackmagic -M "option"
<Same output with immediate return. This tests monitor as main action.>
$ ./blackmagic -M "option" -r -a 0x08000000 -S 0x10 bla.bin
usage: monitor option erase
...
Read/Verify succeeded for 16 bytes,   16.000 kiB/s
$ ./blackmagic -M "option" bla.bin
usage: monitor option erase
...
Flash Write succeeded for 16 bytes,    0.219 kiB/s
```