### PR TITLE
adiv5_swdp: Initialize a volatile variable

### DIFF
--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -91,7 +91,7 @@ int adiv5_swdp_scan(uint32_t targetid)
 	 * 20 bits start of reset another reset sequence*/
 	initial_dp->seq_out(0x1a0, 12);
 	uint32_t idcode = 0;
-	volatile uint32_t target_id;
+	volatile uint32_t target_id = 0;
 	bool scan_multidrop = true;
 	if (!targetid || !initial_dp->dp_low_write) {
 		/* No targetID given on the command line or probe can not


### PR DESCRIPTION
GCC did not warn about possibly missing initialization and so for gdb target
was not recognized.