### PR TITLE
type of ‘assert’ defaults to ‘int’

### DIFF
--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -48,7 +48,7 @@ int cmsis_dap_jtagtap_init(jtag_proc_t *jtag_proc) {return -1;}
 int dap_swdptap_init(ADIv5_DP_t *dp) {return -1;}
 int dap_jtag_dp_init(ADIv5_DP_t *dp) {return -1;}
 void dap_swd_configure(uint8_t cfg) {};
-void dap_srst_set_val(assert) {};
+void dap_srst_set_val(bool assert) {};
 # pragma GCC diagnostic pop
 
 #endif


### PR DESCRIPTION
when running CC=x86_64-w64-mingw32-gcc make PROBE_HOST=hosted