### PR TITLE
crc32: define `start_time` when debug is enabled

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -106,9 +106,11 @@ int generic_crc32(target *t, uint32_t *crc_res, uint32_t base, size_t len)
 	 * 22 s @ 4k and 21 s @ 64k
 	 */
 	uint8_t bytes[0x1000];
-	uint32_t start_time = platform_time_ms();
 #else
 	uint8_t bytes[128];
+#endif
+#if defined(ENABLE_DEBUG)
+	uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t last_time = platform_time_ms();
 	while (len) {


### PR DESCRIPTION
The variable `start_time` indicates when a CRC32 operation began. This
variable is used to benchmark the speed of the CRC32 function.

Currently, this is tied to `PC_HOSTED`. However, the actual usage is
tied to `DEBUG_WARN`. This means that the variable is undefined when
`DEBUG_WARN` is defined and we're not configured for `PC_HOSTED` mode.

Add macro guards around this variable so that it is defined when
debugging is enabled, rather than only when building on `PC_HOSTED`.

Signed-off-by: Sean Cross <sean@xobs.io>