### PR TITLE
Add support for Samd09

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -106,9 +106,11 @@ int generic_crc32(target *t, uint32_t *crc_res, uint32_t base, size_t len)
 	 * 22 s @ 4k and 21 s @ 64k
 	 */
 	uint8_t bytes[0x1000];
-	uint32_t start_time = platform_time_ms();
 #else
 	uint8_t bytes[128];
+#endif
+#if defined(ENABLE_DEBUG)
+	uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t last_time = platform_time_ms();
 	while (len) {

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -22,6 +22,7 @@
  * programming.
  *
  * Tested with
+ * * SAMD09D14A (rev B)
  * * SAMD20E17A (rev C)
  * * SAMD20J18A (rev B)
  * * SAMD21J18A (rev B)
@@ -128,7 +129,7 @@ const struct command_s samd_cmd_list[] = {
 #define SAMD_STATUSB_PROT		(1 << 16)
 
 /* Device Identification Register (DID) */
-#define SAMD_DID_MASK			0xFF3C0000
+#define SAMD_DID_MASK			0xFF380000
 #define SAMD_DID_CONST_VALUE		0x10000000
 #define SAMD_DID_DEVSEL_MASK		0xFF
 #define SAMD_DID_DEVSEL_POS		0
@@ -384,6 +385,7 @@ struct samd_descr samd_parse_device_id(uint32_t did)
 			}
 			break;
 		case 3: samd.series = 11; break;
+		case 4: samd.series = 9; break;
 		default: samd.series = 0; break;
 	}
 	/* Revision */
@@ -421,6 +423,23 @@ struct samd_descr samd_parse_device_id(uint32_t did)
 		}
 		samd.pin = 'D';
 		samd.mem = 14 - (devsel % 3);
+		samd.variant = 'A';
+		break;
+	case 9: /* SAM D09 */
+		samd.ram_size = 4096;
+		switch (devsel) {
+			case 0:
+				samd.pin = 'D';
+				samd.mem = 14;
+				samd.flash_size = 16384;
+				samd.package[0] = 'M';
+				break;
+			case 7:
+				samd.pin = 'C';
+				samd.mem = 13;
+				samd.flash_size = 8192;
+				break;
+		}
 		samd.variant = 'A';
 		break;
 	}
@@ -479,14 +498,14 @@ bool samd_probe(target *t)
 	/* Part String */
 	if (protected) {
 		sprintf(priv_storage->samd_variant_string,
-		        "Atmel SAM%c%d%c%d%c%s (rev %c) (PROT=1)",
+		        "Atmel SAM%c%02d%c%d%c%s (rev %c) (PROT=1)",
 		        samd.family,
 		        samd.series, samd.pin, samd.mem,
 		        samd.variant,
 		        samd.package, samd.revision);
 	} else {
 		sprintf(priv_storage->samd_variant_string,
-		        "Atmel SAM%c%d%c%d%c%s (rev %c)",
+		        "Atmel SAM%c%02d%c%d%c%s (rev %c)",
 		        samd.family,
 		        samd.series, samd.pin, samd.mem,
 		        samd.variant,

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -341,6 +341,8 @@ struct samd_descr {
 	uint8_t series;
 	char revision;
 	char pin;
+	uint32_t ram_size;
+	uint32_t flash_size;
 	uint8_t mem;
 	char variant;
 	char package[3];
@@ -351,6 +353,8 @@ struct samd_descr samd_parse_device_id(uint32_t did)
 	uint8_t i = 0;
 	const struct samd_part *parts = samd_d21_parts;
 	memset(samd.package, 0, 3);
+	samd.ram_size = 0x8000;
+	samd.flash_size = 0x40000;
 
 	uint8_t family = (did >> SAMD_DID_FAMILY_POS)
 	  & SAMD_DID_FAMILY_MASK;
@@ -513,8 +517,8 @@ bool samd_probe(target *t)
 		t->attach = samd_protected_attach;
 	}
 
-	target_add_ram(t, 0x20000000, 0x8000);
-	samd_add_flash(t, 0x00000000, 0x40000);
+	target_add_ram(t, 0x20000000, samd.ram_size);
+	samd_add_flash(t, 0x00000000, samd.flash_size);
 	target_add_commands(t, samd_cmd_list, "SAMD");
 
 	/* If we're not in reset here */


### PR DESCRIPTION
This adds support for the SAMD09, used in the Adafruit SeeSaw board.