### PR TITLE
Stm32 mem fixes

### DIFF
--- a/scripts/stm32_mem.py
+++ b/scripts/stm32_mem.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
 from time import sleep
 import struct
 import os

--- a/scripts/stm32_mem.py
+++ b/scripts/stm32_mem.py
@@ -72,7 +72,7 @@ def stm32_read(dev):
 	return data
 
 def stm32_manifest(dev):
-	dev.download(0, "")
+	dev.download(0, b"")
 	while True:
 		try:
 			status = dev.get_status()

--- a/scripts/stm32_mem.py
+++ b/scripts/stm32_mem.py
@@ -138,7 +138,7 @@ def stm32_scan(args, test):
 		product = dfudev.handle.getString(dfudev.dev.iProduct, 96).decode('utf8')
 		serial_no = dfudev.handle.getString(dfudev.dev.iSerialNumber, 30).decode('utf8')
 		if args.serial_target:
-			if man == "Black Sphere Technologies" and serial_no ==	args.serial_target:
+			if man == "Black Sphere Technologies" and serial_no == args.serial_target:
 				break
 		else:
 			if man == "Black Sphere Technologies":
@@ -236,7 +236,7 @@ if __name__ == "__main__":
 	bin = file.read()
 	len = len(bin)
 	addr = start
-	print("-")
+	print("\n-")
 	while bin:
 		try:
 			stm32_set_address(dfudev, addr)
@@ -251,7 +251,7 @@ if __name__ == "__main__":
 		else :
 			size = len
 		if bin[:size] != bytearray(data[:size]) :
-			print ("\nMitmatch in block at	0x%08X" % addr)
+			print ("\nMismatch in block at 0x%08X" % addr)
 			break;
 		bin = bin[1024:]
 		addr += 1024


### PR DESCRIPTION
Avoid crash at end of programing.

Also add minor fixes.

```
-
USB Device Firmware Upgrade - Host Utility -- version 1.2
Copyright (C) 2011  Black Sphere Technologies
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
-
Device ID:       1d50:6017
Manufacturer:    Black Sphere Technologies
Product:         Black Magic Probe (Upgrade)
Serial:          7BAE5BAD
-rogramming memory at 0x0801B400
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/usb/core.py", line 1021, in ctrl_transfer
    buff = util.create_buffer(data_or_wLength)
  File "/usr/lib/python3/dist-packages/usb/util.py", line 162, in create_buffer
    return array.array('B', _dummy_s * length)
TypeError: can't multiply sequence by non-int of type 'str'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/usb/_interop.py", line 92, in as_array
    return array.array('B', data)
TypeError: cannot use a str to initialize an array with typecode 'B'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/nicolas/work/stm32/blackmagic/./scripts/stm32_mem.py", line 261, in <module>
    stm32_manifest(dfudev)
  File "/home/nicolas/work/stm32/blackmagic/./scripts/stm32_mem.py", line 75, in stm32_manifest
    dev.download(0, "")
  File "/home/nicolas/work/stm32/blackmagic/scripts/dfu.py", line 95, in download
    self.handle.controlMsg(usb.ENDPOINT_OUT | usb.TYPE_CLASS |
  File "/usr/lib/python3/dist-packages/usb/legacy.py", line 205, in controlMsg
    return self.dev.ctrl_transfer(
  File "/usr/lib/python3/dist-packages/usb/core.py", line 1023, in ctrl_transfer
    buff = _interop.as_array(data_or_wLength)
  File "/usr/lib/python3/dist-packages/usb/_interop.py", line 97, in as_array
    a.fromstring(data) # deprecated since 3.2
AttributeError: 'array.array' object has no attribute 'fromstring'
```
